### PR TITLE
fix: add ssh-keyscan for freshly provisioned servers in launch wizard

### DIFF
--- a/skills/djstudio/launch.md
+++ b/skills/djstudio/launch.md
@@ -96,6 +96,13 @@ just terraform hetzner apply
 
 Wait for apply to complete. If it fails, show the error and stop.
 
+Then add the new server to SSH known hosts (required to avoid host key verification
+failures when fetching the kubeconfig):
+```bash
+server_ip=$(just terraform-value hetzner server_public_ip)
+ssh-keyscan -H "$server_ip" >> ~/.ssh/known_hosts
+```
+
 Then fetch the kubeconfig:
 ```bash
 just get-kubeconfig


### PR DESCRIPTION
Closes #81

After `terraform apply` provisions a new Hetzner server, `just get-kubeconfig` fails with "Host key verification failed" because the new server IP is not in `~/.ssh/known_hosts`.

Add a `ssh-keyscan -H <server_ip> >> ~/.ssh/known_hosts` step before `just get-kubeconfig`, using the `server_public_ip` from the Terraform output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)