### PR TITLE
fix: show required cloud accounts checklist at start of launch wizard

### DIFF
--- a/skills/djstudio/launch.md
+++ b/skills/djstudio/launch.md
@@ -7,6 +7,41 @@ where it left off.
 
 ---
 
+## Required accounts checklist
+
+Before starting, tell the user:
+
+> **Before we begin, make sure you have accounts and credentials ready for these services.
+> The wizard will ask for them during setup — having them ready will save you from
+> stopping mid-flow.**
+>
+> **1. Hetzner Cloud** ([console.hetzner.cloud](https://console.hetzner.cloud))
+> - A project created (or select an existing one)
+> - API token with **Read & Write** permissions
+>   (Security → API Tokens → Generate API Token)
+> - *(If using object storage)* S3 credentials
+>   (Security → S3 credentials → Generate credentials)
+>
+> **2. Cloudflare** ([dash.cloudflare.com](https://dash.cloudflare.com))
+> - Your domain added to Cloudflare and showing as **Active**
+>   (nameservers must be pointing to Cloudflare at your registrar)
+> - API token with Zone permissions:
+>   Zone (Edit), Zone Settings (Edit), DNS (Edit), Page Rules (Edit),
+>   Zone WAF (Edit), Transform Rules (Edit), SSL and Certificates (Edit)
+>
+> **3. Mailgun** ([mailgun.com](https://www.mailgun.com)) — *optional, required for email*
+> - A sending domain configured (e.g. `mg.yourdomain.com`)
+> - Sending API key
+> - DKIM TXT record value
+>   (Sending → Domains → your domain → DNS Records)
+>
+> Do you have all of the above ready? (y/n)
+
+If the user answers **n**, tell them to prepare the accounts above and re-run
+`/djstudio launch` when ready. Stop.
+
+---
+
 ## Pre-flight checks
 
 Run all of the following before proceeding. If any fail, tell the user what to install


### PR DESCRIPTION
Closes #89

The wizard was asking for API tokens and credentials mid-flow, with no prior warning. Users who didn't have accounts set up were forced to stop, create credentials, and restart.

Add a "Required accounts" checklist at the very start of the wizard — before the pre-flight tool checks — listing all three services (Hetzner, Cloudflare, Mailgun) with what specifically is needed from each. Ask the user to confirm they have everything before proceeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)