### PR TITLE
docs: document sorl-thumbnail S3 behaviour in File-Storage.md

### DIFF
--- a/template/docs/File-Storage.md
+++ b/template/docs/File-Storage.md
@@ -142,3 +142,41 @@ Storage is S3-compatible, so the same library works without modification.
 
 `django-storages[s3]` is included in `pyproject.toml` automatically when `use_storage=y`.
 It brings in `boto3` as a transitive dependency. No manual `uv add` is needed.
+
+## sorl-thumbnail and S3
+
+If you use [sorl-thumbnail](https://sorl-thumbnail.readthedocs.io/) with S3 storage,
+there are several important behaviours to be aware of:
+
+### Management commands are unreliable with S3
+
+The `thumbnail cleanup`, `thumbnail clear`, `thumbnail clear_delete_all`, and
+`thumbnail clear_delete_referenced` management commands use `storage.listdir()`
+internally. This does not work correctly with all S3-compatible backends, including
+Hetzner Object Storage. These commands will complete without errors but will **not**
+delete thumbnail files from S3.
+
+Do not rely on management commands for thumbnail cleanup in production S3 setups.
+
+### Thumbnail cleanup on model deletion works via signal
+
+sorl-thumbnail's `ImageField` fires a `post_delete` signal that deletes associated
+thumbnail cache files from S3 when a model instance is deleted. This is the reliable
+cleanup path and works correctly.
+
+### Original files are not auto-deleted
+
+Django does not delete `ImageField`/`FileField` files from storage when a model
+instance is deleted. This is standard Django behaviour. Add an explicit `post_delete`
+signal to handle it:
+
+```python
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
+
+@receiver(post_delete, sender=Photo)
+def delete_photo_file(sender, instance, **kwargs):
+    instance.photo.delete(save=False)
+```
+
+Without this, deleted model instances will leave orphaned files in your S3 bucket.


### PR DESCRIPTION
Closes #91

Add a section to `docs/File-Storage.md` covering sorl-thumbnail with S3 storage:

1. **Management commands are unreliable with S3** — `thumbnail clear_delete_all` etc. use `storage.listdir()` which doesn't work with Hetzner Object Storage. Don't rely on them in production.
2. **Thumbnail cleanup on model deletion works via signal** — sorl-thumbnail's `ImageField` fires `post_delete` correctly. This is the reliable path.
3. **Original files are not auto-deleted** — Django's standard `ImageField`/`FileField` behaviour. Includes a `post_delete` signal example to handle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)