### PR TITLE
fix: add styled templates for missing allauth account views

### DIFF
--- a/template/templates/account/confirm_login_code.html
+++ b/template/templates/account/confirm_login_code.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% title_tag _("Sign In") %}{% endblock title %}
+
+{% block content %}
+  <div class="mx-auto max-w-md py-12">
+    <h1 class="mb-6 text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+      {% translate "Enter Sign-In Code" %}
+    </h1>
+    <p class="mb-4 text-sm text-zinc-600 dark:text-zinc-400">
+      {% if email %}
+        {% blocktranslate %}We sent a code to <strong>{{ email }}</strong>. The code expires shortly — enter it below.{% endblocktranslate %}
+      {% elif phone %}
+        {% blocktranslate %}We sent a code to <strong>{{ phone }}</strong>. The code expires shortly — enter it below.{% endblocktranslate %}
+      {% else %}
+        {% translate "We sent you a code. The code expires shortly — enter it below." %}
+      {% endif %}
+    </p>
+    <form method="post" action="{% url 'account_confirm_login_code' %}" class="space-y-4">
+      {% csrf_token %}
+      {{ verify_form }}
+      {{ redirect_field }}
+      <div class="flex flex-wrap gap-3">
+        <button type="submit" class="btn btn-primary">{% translate "Confirm" %}</button>
+        {% if can_resend %}
+          <button type="submit" form="resend-form" class="btn btn-secondary">
+            {% translate "Request new code" %}
+          </button>
+        {% endif %}
+      </div>
+    </form>
+    {% if can_resend %}
+      <form id="resend-form" method="post" action="{% url 'account_confirm_login_code' %}">
+        {% csrf_token %}
+        <input type="hidden" name="action" value="resend" />
+        {{ redirect_field }}
+      </form>
+    {% endif %}
+  </div>
+{% endblock content %}

--- a/template/templates/account/confirm_password_reset_code.html
+++ b/template/templates/account/confirm_password_reset_code.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% title_tag _("Password Reset") %}{% endblock title %}
+
+{% block content %}
+  <div class="mx-auto max-w-md py-12">
+    <h1 class="mb-6 text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+      {% translate "Enter Password Reset Code" %}
+    </h1>
+    <p class="mb-4 text-sm text-zinc-600 dark:text-zinc-400">
+      {% if email %}
+        {% blocktranslate %}We sent a password reset code to <strong>{{ email }}</strong>. The code expires shortly — enter it below.{% endblocktranslate %}
+      {% else %}
+        {% translate "We sent you a password reset code. The code expires shortly — enter it below." %}
+      {% endif %}
+    </p>
+    <form method="post" action="{% url 'account_confirm_password_reset_code' %}" class="space-y-4">
+      {% csrf_token %}
+      {{ verify_form }}
+      {{ redirect_field }}
+      <div class="flex flex-wrap gap-3">
+        <button type="submit" class="btn btn-primary">{% translate "Confirm" %}</button>
+        {% if can_resend %}
+          <button type="submit" form="resend-form" class="btn btn-secondary">
+            {% translate "Request new code" %}
+          </button>
+        {% endif %}
+      </div>
+    </form>
+    {% if can_resend %}
+      <form id="resend-form" method="post" action="{% url 'account_confirm_password_reset_code' %}">
+        {% csrf_token %}
+        <input type="hidden" name="action" value="resend" />
+        {{ redirect_field }}
+      </form>
+    {% endif %}
+    {% if change_form %}
+      <div class="mt-8">
+        <h2 class="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+          {% translate "Use a different email address" %}
+        </h2>
+        <form method="post" action="{% url 'account_confirm_password_reset_code' %}" class="space-y-4">
+          {% csrf_token %}
+          {{ change_form }}
+          {{ redirect_field }}
+          <div>
+            <button type="submit" name="action" value="change" class="btn btn-secondary">
+              {% translate "Change" %}
+            </button>
+          </div>
+        </form>
+      </div>
+    {% endif %}
+  </div>
+{% endblock content %}

--- a/template/templates/account/confirm_phone_verification_code.html
+++ b/template/templates/account/confirm_phone_verification_code.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% title_tag _("Phone Verification") %}{% endblock title %}
+
+{% block content %}
+  <div class="mx-auto max-w-md py-12">
+    <h1 class="mb-6 text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+      {% translate "Enter Phone Verification Code" %}
+    </h1>
+    {% if phone %}
+      <p class="mb-4 text-sm text-zinc-600 dark:text-zinc-400">
+        {% blocktranslate %}We sent a verification code to <strong>{{ phone }}</strong>. The code expires shortly — enter it below.{% endblocktranslate %}
+      </p>
+    {% endif %}
+    <form method="post" action="{% url 'account_verify_phone' %}" class="space-y-4">
+      {% csrf_token %}
+      {{ verify_form }}
+      {{ redirect_field }}
+      <div class="flex flex-wrap gap-3">
+        <button type="submit" class="btn btn-primary">{% translate "Verify" %}</button>
+        {% if can_resend %}
+          <button type="submit" form="resend-form" class="btn btn-secondary">
+            {% translate "Request new code" %}
+          </button>
+        {% endif %}
+      </div>
+    </form>
+    {% if can_resend %}
+      <form id="resend-form" method="post" action="{% url 'account_verify_phone' %}">
+        {% csrf_token %}
+        <input type="hidden" name="action" value="resend" />
+        {{ redirect_field }}
+      </form>
+    {% endif %}
+    {% if change_form %}
+      <div class="mt-8">
+        <h2 class="mb-4 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+          {% translate "Use a different phone number" %}
+        </h2>
+        <form method="post" action="{% url 'account_verify_phone' %}" class="space-y-4">
+          {% csrf_token %}
+          {{ change_form }}
+          {{ redirect_field }}
+          <div>
+            <button type="submit" name="action" value="change" class="btn btn-secondary">
+              {% translate "Change" %}
+            </button>
+          </div>
+        </form>
+      </div>
+    {% endif %}
+  </div>
+{% endblock content %}

--- a/template/templates/account/email_change.html
+++ b/template/templates/account/email_change.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% title_tag _("Change Email") %}{% endblock title %}
+
+{% block content %}
+  <div class="mx-auto max-w-md py-12">
+    <h1 class="mb-6 text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+      {% translate "Change Email" %}
+    </h1>
+    {% if current_emailaddress %}
+      <p class="mb-4 text-sm text-zinc-600 dark:text-zinc-400">
+        {% blocktranslate with email=current_emailaddress.email %}
+          Your current email address is <strong>{{ email }}</strong>.
+        {% endblocktranslate %}
+      </p>
+    {% endif %}
+    {% if new_emailaddress %}
+      <div class="mb-6 rounded border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
+        <p class="mb-2">
+          {% blocktranslate with email=new_emailaddress.email %}
+            A verification email has been sent to <strong>{{ email }}</strong>. Check your inbox and
+            click the link to confirm the change.
+          {% endblocktranslate %}
+        </p>
+        <form method="post" action="{% url 'account_email' %}" class="flex gap-2">
+          {% csrf_token %}
+          <input type="hidden" name="email" value="{{ new_emailaddress.email }}" />
+          <button type="submit" name="action_send" class="btn btn-secondary">
+            {% translate "Re-send Verification" %}
+          </button>
+          {% if current_emailaddress %}
+            <button type="submit" name="action_remove" class="btn btn-danger">
+              {% translate "Cancel Change" %}
+            </button>
+          {% endif %}
+        </form>
+      </div>
+    {% endif %}
+    <form method="post" action="{% url 'account_email' %}" class="space-y-4">
+      {% csrf_token %}
+      {{ form }}
+      <div>
+        <button type="submit" name="action_add" class="btn btn-primary">
+          {% translate "Change Email" %}
+        </button>
+      </div>
+    </form>
+  </div>
+{% endblock content %}

--- a/template/templates/account/phone_change.html
+++ b/template/templates/account/phone_change.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% title_tag _("Change Phone") %}{% endblock title %}
+
+{% block content %}
+  <div class="mx-auto max-w-md py-12">
+    <h1 class="mb-6 text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+      {% translate "Change Phone Number" %}
+    </h1>
+    {% if phone %}
+      <p class="mb-4 text-sm text-zinc-600 dark:text-zinc-400">
+        {% blocktranslate %}
+          Your current phone number is <strong>{{ phone }}</strong>.
+        {% endblocktranslate %}
+        {% if not phone_verified %}
+          <span class="ml-1 text-amber-600 dark:text-amber-400">
+            {% translate "(unverified)" %}
+          </span>
+        {% endif %}
+      </p>
+      {% if not phone_verified %}
+        <div class="mb-6 rounded border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
+          {% translate "Your phone number is still pending verification." %}
+          <form id="verify-phone" method="post" action="{% url 'account_change_phone' %}" class="mt-2">
+            {% csrf_token %}
+            <input type="hidden" name="action" value="verify" />
+            <button type="submit" class="btn btn-secondary">
+              {% translate "Re-send Verification" %}
+            </button>
+          </form>
+        </div>
+      {% endif %}
+    {% endif %}
+    <form method="post" action="{% url 'account_change_phone' %}" class="space-y-4">
+      {% csrf_token %}
+      {{ form }}
+      <div>
+        <button type="submit" name="action_add" class="btn btn-primary">
+          {% translate "Change Phone Number" %}
+        </button>
+      </div>
+    </form>
+  </div>
+{% endblock content %}

--- a/template/templates/account/request_login_code.html
+++ b/template/templates/account/request_login_code.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% title_tag _("Sign In") %}{% endblock title %}
+
+{% block content %}
+  <div class="mx-auto max-w-md py-12">
+    <h1 class="mb-6 text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+      {% translate "Sign In with Code" %}
+    </h1>
+    <p class="mb-4 text-sm text-zinc-600 dark:text-zinc-400">
+      {% translate "Enter your email or phone number and we will send you a one-time sign-in code." %}
+    </p>
+    <form method="post" action="{% url 'account_request_login_code' %}" class="space-y-4">
+      {% csrf_token %}
+      {{ form }}
+      {{ redirect_field }}
+      <div>
+        <button type="submit" class="btn btn-primary">{% translate "Send Code" %}</button>
+      </div>
+    </form>
+    <p class="mt-4 text-sm text-zinc-600 dark:text-zinc-400">
+      <a href="{% url 'account_login' %}" class="underline">{% translate "Other sign-in options" %}</a>
+    </p>
+  </div>
+{% endblock content %}

--- a/template/templates/account/signup_by_passkey.html
+++ b/template/templates/account/signup_by_passkey.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% title_tag _("Sign Up") %}{% endblock title %}
+
+{% block content %}
+  <div class="mx-auto max-w-md py-12">
+    <h1 class="mb-6 text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+      {% translate "Passkey Sign Up" %}
+    </h1>
+    <p class="mb-4 text-sm text-zinc-600 dark:text-zinc-400">
+      {% blocktranslate with url=login_url %}Already have an account? <a class="underline" href="{{ url }}">Sign in</a>.{% endblocktranslate %}
+    </p>
+    <form method="post" action="{% url 'account_signup_by_passkey' %}" class="space-y-4">
+      {% csrf_token %}
+      {{ form }}
+      {{ redirect_field }}
+      <div>
+        <button type="submit" class="btn btn-primary">{% translate "Sign Up with Passkey" %}</button>
+      </div>
+    </form>
+    <p class="mt-6 text-sm text-zinc-600 dark:text-zinc-400">
+      <a href="{{ signup_url }}" class="underline">{% translate "Other sign-up options" %}</a>
+    </p>
+  </div>
+{% endblock content %}

--- a/template/templates/account/snippets/already_logged_in.html
+++ b/template/templates/account/snippets/already_logged_in.html
@@ -1,0 +1,7 @@
+{% load i18n %}
+{% load account %}
+{% user_display user as user_display %}
+<div class="mb-4 rounded border border-blue-200 bg-blue-50 p-4 text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-200">
+  <strong>{% translate "Note" %}:</strong>
+  {% blocktranslate %}You are already logged in as {{ user_display }}.{% endblocktranslate %}
+</div>

--- a/template/templates/account/snippets/warn_no_email.html
+++ b/template/templates/account/snippets/warn_no_email.html
@@ -1,0 +1,5 @@
+{% load i18n %}
+<div class="mb-4 rounded border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
+  <strong>{% translate "Warning:" %}</strong>
+  {% translate "You currently do not have any email address set up. You should really add an email address so you can receive notifications, reset your password, etc." %}
+</div>


### PR DESCRIPTION
Closes #90

Several allauth account view templates were missing from the template directory, causing allauth to fall back to its own unstyled default templates (which use the `{% element %}` component system incompatible with our Tailwind CSS setup).

Add styled templates for all missing account views, following the same Tailwind CSS + `base.html` pattern as the existing templates:

**New templates:**
- `account/email_change.html` — email change flow
- `account/request_login_code.html` — passwordless login: request a code
- `account/confirm_login_code.html` — passwordless login: confirm the code
- `account/confirm_password_reset_code.html` — password reset via code
- `account/phone_change.html` — phone number management
- `account/confirm_phone_verification_code.html` — phone verification code
- `account/signup_by_passkey.html` — passkey sign-up
- `account/snippets/already_logged_in.html` — "already logged in" notice
- `account/snippets/warn_no_email.html` — "no email set" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)