### PR TITLE
fix: add datetimeinput and clearablefileinput partials to form/field.html

### DIFF
--- a/template/design/forms.md
+++ b/template/design/forms.md
@@ -103,7 +103,9 @@ Built-in widgets and their partials:
 | `EmailInput` | `emailinput` |
 | `URLInput` | `urlinput` |
 | `FileInput` | `fileinput` |
+| `ClearableFileInput` | `clearablefileinput` |
 | `DateInput` | `dateinput` |
+| `DateTimeInput` | `datetimeinput` |
 | `Textarea` | `textarea` |
 | `CheckboxInput` | `checkboxinput` |
 | `CheckboxSelectMultiple` | `checkboxselectmultiple` |

--- a/template/templates/form/field.html
+++ b/template/templates/form/field.html
@@ -55,12 +55,19 @@
 {% partialdef textinput %}{% partial input %}{% endpartialdef %}
 {% partialdef emailinput %}{% partial input %}{% endpartialdef %}
 {% partialdef fileinput %}{% partial input %}{% endpartialdef %}
+{% partialdef clearablefileinput %}{% partial input %}{% endpartialdef %}
 {% partialdef urlinput %}{% partial input %}{% endpartialdef %}
 
 {# Date #}
 {% partialdef dateinput %}
   {% partial label %}
   {% render_field field class="form-input" type="date" %}
+{% endpartialdef %}
+
+{# Date + time #}
+{% partialdef datetimeinput %}
+  {% partial label %}
+  {% render_field field class="form-input" type="datetime-local" %}
 {% endpartialdef %}
 
 {# Textarea #}


### PR DESCRIPTION
## Summary

- Adds `{% partialdef datetimeinput %}` partial with `type="datetime-local"` so `DateTimeField` forms render correctly via `{{ field.as_field_group }}` (fixes #106)
- Adds `{% partialdef clearablefileinput %}` partial so edit forms on models with `FileField` no longer raise `TemplateDoesNotExist: clearablefileinput` (fixes #109)
- Updates `design/forms.md` widget table to include `ClearableFileInput` and `DateTimeInput`

## Test plan

- [ ] Generate a project with a form that has a `DateTimeField` — `{{ field.as_field_group }}` renders without error
- [ ] Generate a project with a model edit form that has a `FileField` — edit form renders without error

Closes #106, #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)