### PR TITLE
fix: use pg_catalog.simple in search trigger to match Searchable default

### DIFF
--- a/template/docs/Models.md
+++ b/template/docs/Models.md
@@ -51,7 +51,14 @@ Item.objects.search("django", "title", "description")  # override fields
 
 ### Search Vector Updates via Triggers
 
-Maintain `search_vector` via a database trigger rather than `post_save`:
+Maintain `search_vector` via a database trigger rather than `post_save`.
+
+**Important:** the trigger config and the `Searchable.search()` config must
+match. The mixin defaults to `config='simple'`, so the trigger must also use
+`pg_catalog.simple`. Using `pg_catalog.english` in the trigger would apply
+English stemming when building the vector (`"alice"` → `"alic"`) but the query
+would search for the literal token `"alice"`, silently breaking search for many
+common words.
 
 ```python
 # migrations/0002_add_search_trigger.py
@@ -67,7 +74,7 @@ class Migration(migrations.Migration):
 CREATE TRIGGER myapp_update_search_trigger
 BEFORE INSERT OR UPDATE OF title, description ON myapp_item
 FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger(
-    search_vector, 'pg_catalog.english', title, description);
+    search_vector, 'pg_catalog.simple', title, description);
 UPDATE myapp_item SET search_vector = NULL;""",
             reverse_sql=(
                 "DROP TRIGGER IF EXISTS myapp_update_search_trigger ON myapp_item;"


### PR DESCRIPTION
## Summary

- Changes the `tsvector_update_trigger` example in `docs/Models.md` from `pg_catalog.english` to `pg_catalog.simple`
- Adds an explanation of why the trigger config and `Searchable.search()` config must match — mismatched configs silently break search (English stemming produces `"alic"` for `"Alice"`, but the simple-config query searches for `"alice"`)

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)