### PR TITLE
fix: allow all just subcommands in generated Claude Code settings.json

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -149,14 +149,7 @@ def install_claude_hooks() -> None:
     settings = {
         "permissions": {
             "allow": [
-                "Bash(just lint:*)",
-                "Bash(just test:*)",
-                "Bash(just typecheck:*)",
-                "Bash(just dj:*)",
-                "Bash(just start:*)",
-                "Bash(just stop:*)",
-                "Bash(just serve:*)",
-                "Bash(just psql:*)",
+                "Bash(just:*)",
                 "Bash(git status:*)",
                 "Bash(git log:*)",
                 "Bash(git diff:*)",


### PR DESCRIPTION
## Summary

Replaces the exhaustive per-subcommand list (`just lint`, `just test`, `just typecheck`, `just dj`, `just start`, `just stop`, `just serve`, `just psql`) with a single `Bash(just:*)` wildcard permission.

All project commands use `just` as the task runner. Requiring user approval per subcommand adds friction with no security benefit.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)