### PR TITLE
fix: use if/else form instantiation instead of request.POST or None

### DIFF
--- a/skills/djstudio/create-crud.md
+++ b/skills/djstudio/create-crud.md
@@ -99,11 +99,14 @@ def <model_lower>_detail(request: HttpRequest, pk: int) -> TemplateResponse:
 @login_required
 @require_form_methods
 def <model_lower>_create(request: HttpRequest) -> TemplateResponse | HttpResponseRedirect:
-    form = <model_name>Form(request.POST or None)
-    if request.method == "POST" and form.is_valid():
-        form.save()
-        messages.success(request, "<model_name> created.")
-        return redirect(reverse("<app_name>:<model_lower>_list"))
+    if request.method == "POST":
+        form = <model_name>Form(request.POST)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "<model_name> created.")
+            return redirect(reverse("<app_name>:<model_lower>_list"))
+    else:
+        form = <model_name>Form()
     return render_partial_response(
         request,
         "<app_name>/<model_lower>_form.html",
@@ -119,11 +122,14 @@ def <model_lower>_edit(
     request: HttpRequest, pk: int
 ) -> TemplateResponse | HttpResponseRedirect:
     <model_lower> = get_object_or_404(<model_name>, pk=pk)
-    form = <model_name>Form(request.POST or None, instance=<model_lower>)
-    if request.method == "POST" and form.is_valid():
-        form.save()
-        messages.success(request, "<model_name> updated.")
-        return redirect(reverse("<app_name>:<model_lower>_list"))
+    if request.method == "POST":
+        form = <model_name>Form(request.POST, instance=<model_lower>)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "<model_name> updated.")
+            return redirect(reverse("<app_name>:<model_lower>_list"))
+    else:
+        form = <model_name>Form(instance=<model_lower>)
     return render_partial_response(
         request,
         "<app_name>/<model_lower>_form.html",

--- a/template/design/forms.md
+++ b/template/design/forms.md
@@ -169,11 +169,14 @@ The `form/field.html` template applies `has-errors` to the fieldset and renders 
 
 ```python
 def my_view(request):
-    form = MyForm(request.POST or None)
-    if request.method == "POST" and form.is_valid():
-        form.save()
-        messages.success(request, "Saved.")
-        return redirect("index")
+    if request.method == "POST":
+        form = MyForm(request.POST)
+        if form.is_valid():
+            form.save()
+            messages.success(request, "Saved.")
+            return redirect("index")
+    else:
+        form = MyForm()
     return TemplateResponse(request, "my_page.html", {"form": form})
 ```
 


### PR DESCRIPTION
## Summary

Replaces the `request.POST or None` anti-pattern with the standard Django if/else form instantiation in `create-crud.md` view stubs and the `design/forms.md` validation example.

**Why:** `request.POST or None` evaluates as `None` for an empty POST body (a form with no required fields), bypassing validation entirely. The if/else pattern is idiomatic Django and avoids the redundant `request.method == "POST"` check alongside the form construction.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)