### PR TITLE
docs: prefer fixtures over inline factory calls in generated CRUD tests

### DIFF
--- a/skills/djstudio/create-crud.md
+++ b/skills/djstudio/create-crud.md
@@ -270,6 +270,13 @@ urlpatterns = [
 
 ### 5. Tests
 
+**Fixture convention:** `create-model` Step 6 creates a `<model_lower>` pytest
+fixture in `<package_name>/<app_name>/tests/fixtures.py`. Use it as a parameter
+in tests that need a single instance — do not call `<model_name>Factory()`
+directly for those cases. Only use `<model_name>Factory.create_batch()` (or
+direct factory calls) when you need multiple objects or need to control specific
+field values.
+
 Add to `<package_name>/<app_name>/tests/test_views.py`:
 
 ```python
@@ -300,18 +307,16 @@ class Test<model_name>List:
 
 @pytest.mark.django_db
 class Test<model_name>Detail:
-    def test_get(self, client, auth_user):
-        obj = <model_name>Factory()
-        response = client.get(reverse("<app_name>:<model_lower>_detail", args=[obj.pk]))
+    def test_get(self, client, auth_user, <model_lower>):
+        response = client.get(reverse("<app_name>:<model_lower>_detail", args=[<model_lower>.pk]))
         assert response.status_code == 200
 
     def test_404(self, client, auth_user):
         response = client.get(reverse("<app_name>:<model_lower>_detail", args=[0]))
         assert response.status_code == 404
 
-    def test_redirect_if_not_logged_in(self, client):
-        obj = <model_name>Factory()
-        response = client.get(reverse("<app_name>:<model_lower>_detail", args=[obj.pk]))
+    def test_redirect_if_not_logged_in(self, client, <model_lower>):
+        response = client.get(reverse("<app_name>:<model_lower>_detail", args=[<model_lower>.pk]))
         assert response.status_code == 302
 
 
@@ -346,31 +351,27 @@ class Test<model_name>Create:
 
 @pytest.mark.django_db
 class Test<model_name>Edit:
-    def test_get(self, client, auth_user):
-        obj = <model_name>Factory()
-        response = client.get(reverse("<app_name>:<model_lower>_edit", args=[obj.pk]))
+    def test_get(self, client, auth_user, <model_lower>):
+        response = client.get(reverse("<app_name>:<model_lower>_edit", args=[<model_lower>.pk]))
         assert response.status_code == 200
 
-    def test_htmx_partial(self, client, auth_user):
-        obj = <model_name>Factory()
+    def test_htmx_partial(self, client, auth_user, <model_lower>):
         response = client.get(
-            reverse("<app_name>:<model_lower>_edit", args=[obj.pk]),
+            reverse("<app_name>:<model_lower>_edit", args=[<model_lower>.pk]),
             headers={"HX-Request": "true", "HX-Target": "<model_lower>-form"},
         )
         assert response.status_code == 200
 
-    def test_post_valid(self, client, auth_user):
-        obj = <model_name>Factory()
+    def test_post_valid(self, client, auth_user, <model_lower>):
         response = client.post(
-            reverse("<app_name>:<model_lower>_edit", args=[obj.pk]),
+            reverse("<app_name>:<model_lower>_edit", args=[<model_lower>.pk]),
             data={},  # fill in valid form data
         )
         assert response.status_code == 302
 
-    def test_post_invalid(self, client, auth_user):
-        obj = <model_name>Factory()
+    def test_post_invalid(self, client, auth_user, <model_lower>):
         response = client.post(
-            reverse("<app_name>:<model_lower>_edit", args=[obj.pk]),
+            reverse("<app_name>:<model_lower>_edit", args=[<model_lower>.pk]),
             data={},
         )
         assert response.status_code == 200
@@ -379,32 +380,29 @@ class Test<model_name>Edit:
         response = client.get(reverse("<app_name>:<model_lower>_edit", args=[0]))
         assert response.status_code == 404
 
-    def test_redirect_if_not_logged_in(self, client):
-        obj = <model_name>Factory()
-        response = client.get(reverse("<app_name>:<model_lower>_edit", args=[obj.pk]))
+    def test_redirect_if_not_logged_in(self, client, <model_lower>):
+        response = client.get(reverse("<app_name>:<model_lower>_edit", args=[<model_lower>.pk]))
         assert response.status_code == 302
 
 
 @pytest.mark.django_db
 class Test<model_name>Delete:
-    def test_get(self, client, auth_user):
-        obj = <model_name>Factory()
-        response = client.get(reverse("<app_name>:<model_lower>_delete", args=[obj.pk]))
+    def test_get(self, client, auth_user, <model_lower>):
+        response = client.get(reverse("<app_name>:<model_lower>_delete", args=[<model_lower>.pk]))
         assert response.status_code == 200
 
-    def test_delete(self, client, auth_user):
-        obj = <model_name>Factory()
-        response = client.delete(reverse("<app_name>:<model_lower>_delete", args=[obj.pk]))
+    def test_delete(self, client, auth_user, <model_lower>):
+        pk = <model_lower>.pk
+        response = client.delete(reverse("<app_name>:<model_lower>_delete", args=[pk]))
         assert response.status_code == 302
-        assert not <model_name>.objects.filter(pk=obj.pk).exists()
+        assert not <model_name>.objects.filter(pk=pk).exists()
 
     def test_404(self, client, auth_user):
         response = client.delete(reverse("<app_name>:<model_lower>_delete", args=[0]))
         assert response.status_code == 404
 
-    def test_redirect_if_not_logged_in(self, client):
-        obj = <model_name>Factory()
-        response = client.get(reverse("<app_name>:<model_lower>_delete", args=[obj.pk]))
+    def test_redirect_if_not_logged_in(self, client, <model_lower>):
+        response = client.get(reverse("<app_name>:<model_lower>_delete", args=[<model_lower>.pk]))
         assert response.status_code == 302
 ```
 


### PR DESCRIPTION
## Summary

Updates the test template in `create-crud.md` to use the `<model_lower>` pytest fixture (created by `create-model` Step 6) instead of calling `<model_name>Factory()` inline in each test method.

- Tests that need a single instance (`Detail`, `Edit`, `Delete`) now accept the fixture as a parameter
- `List` still uses `Factory.create_batch(3)` since it tests multiple items
- Adds a "Fixture convention" note at the top of the Tests section explaining the rule

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)