### PR TITLE
docs: model conventions for ordering, __str__ FK refs, QuerySet, and noqa

### DIFF
--- a/skills/djstudio/create-model.md
+++ b/skills/djstudio/create-model.md
@@ -52,8 +52,10 @@ Model: <model_name>  →  <package_name>/<app_name>/models.py
   <field>     <FieldType>(<options>)
   …
   __str__:    returns <description>
-  Meta:       ordering = [<fields>]
 ```
+
+Only include `Meta: ordering = [...]` in the sketch if the user has explicitly
+requested a default ordering. Never infer ordering from the model name or fields.
 
 ---
 
@@ -64,8 +66,9 @@ Append to `<package_name>/<app_name>/models.py`. Do not touch existing models.
 Conventions:
 - `from __future__ import annotations` at the top of the file
 - Use `models.TextChoices` / `models.IntegerChoices` for enums, as inner classes
-- Always define `__str__`
-- Add `class Meta` with `ordering` when there is a natural sort order
+- Always define `__str__`; only reference fields on the model itself — never FK
+  relations (e.g. use `self.event_id`, not `self.event`)
+- Only add `class Meta` with `ordering` if the user explicitly requested it
 - FK `related_name` must always be explicit — never rely on the Django default
 
 ```python
@@ -80,11 +83,11 @@ class <model_name>(models.Model):
 
     <field_name> = models.<FieldType>(...)
 
-    class Meta:
-        ordering = [...]
+    # class Meta:
+    #     ordering = [...]  # only if user explicitly requested it
 
     def __str__(self) -> str:
-        return ...
+        return ...  # use self fields only, never FK relations
 ```
 
 ---

--- a/template/docs/Models.md
+++ b/template/docs/Models.md
@@ -22,7 +22,42 @@ class Item(models.Model):
     pub_date = models.DateTimeField(null=True)
 ```
 
-**NOTE** do not add default ordering to the model's `Meta` class. Instead, define an explicit `order_by()` where the model queryset is used. Default ordering can cause unexpected performance issues and is not always desired.
+**Never use `@classmethod` on the model for query logic.** QuerySet methods are
+the correct place — they chain correctly and receive `self` as a `QuerySet`,
+not the model class.
+
+**No `Meta.ordering` by default.** Do not add `ordering` to `Meta` unless the
+user explicitly requests it. Default ordering adds an `ORDER BY` clause to
+every query, including ones that don't need it, and can mask missing indexes.
+Add an explicit `.order_by()` at the call site instead.
+
+## `__str__` convention
+
+`__str__` must only reference fields on the model itself — never FK relations:
+
+```python
+# Good — only reads the model's own column
+def __str__(self) -> str:
+    return self.name
+
+# Good — FK id column is on this table, no extra query
+def __str__(self) -> str:
+    return f"Item {self.pk} (event {self.event_id})"
+
+# Bad — accessing self.event triggers an extra SQL query if not select_related
+def __str__(self) -> str:
+    return f"Item {self.pk} - {self.event}"
+```
+
+FK access in `__str__` causes N+1 queries in list views, admin changelistss, and
+logging — any place that calls `str()` on a queryset without `select_related`.
+
+## Linting bypass comments
+
+Do not add `# noqa: ...`, `# type: ignore`, or similar inline bypass comments
+without first asking the user. In most cases a code change avoids the bypass
+entirely. If there is truly no alternative, state the reason and ask before
+adding the comment.
 
 ## Full-Text Search
 


### PR DESCRIPTION
## Summary

Adds four model conventions to `docs/Models.md` and aligns `create-model.md` with them:

**No `Meta.ordering` by default** (#115): Default ordering adds `ORDER BY` to every query and can hide missing indexes. Only add it when the user explicitly requests it. `create-model.md` Step 2 sketch and Step 3 template updated accordingly.

**No FK references in `__str__`** (#118): Accessing a FK relation in `__str__` triggers an extra SQL query if not `select_related`. Use only the model's own columns. `create-model.md` Step 3 conventions updated.

**Prefer custom QuerySet over `@classmethod`** (#110): QuerySet methods chain correctly and are the Django idiom for query logic. Documents the anti-pattern explicitly.

**No `noqa`/`type: ignore` without approval** (#110): Documents the requirement to ask the user before adding inline bypass comments.

Closes #110, #115, #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)