### PR TITLE
docs: template tag conventions and import+usage same-edit rule in AGENTS.md

### DIFF
--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -258,7 +258,7 @@ If a doc contradicts what you see in existing code, flag it - do not silently pi
 
 ### Template Tags
 
-- **One library per app, named after the app.** Each app has at most one template tag library, placed at `<app>/templatetags/<app>.py` and loaded via `{% load <app> %}`. Do not create multiple libraries per app or use a name that differs from the app name.
+{% raw %}- **One library per app, named after the app.** Each app has at most one template tag library, placed at `<app>/templatetags/<app>.py` and loaded via `{% load <app> %}`. Do not create multiple libraries per app or use a name that differs from the app name.{% endraw %}
 
 - **Test template tags as plain Python functions.** `simple_tag` and `filter` decorators wrap ordinary Python functions. Import and call them directly in tests — do not instantiate `Template`/`Context` unless the test genuinely requires template rendering behaviour.
 
@@ -269,7 +269,7 @@ If a doc contradicts what you see in existing code, flag it - do not silently pi
       assert my_tag(obj) == expected
 
   # Avoid
-  template = Template("{% load myapp %}{% my_tag obj %}")
+  {% raw %}template = Template("{% load myapp %}{% my_tag obj %}"){% endraw %}
   result = template.render(Context({"obj": obj}))
   ```
 


### PR DESCRIPTION
## Summary

Adds two working-convention sections to `AGENTS.md.jinja`:

**Import + first usage in same edit** (#112): The pre-commit ruff hook strips unused imports immediately. Adding an import in one edit and its usage in a second edit causes the import to be removed before the second edit runs. Agents must always add an import and its first usage together.

**Template tag conventions** (#111):
- One library per app, named after the app (`<app>/templatetags/<app>.py`)
- Test `simple_tag` and `filter` functions by calling them directly — no `Template`/`Context` setup needed
- All tag tests go in `<app>/tests/test_template_tags.py`

Closes #111, #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)