### PR TITLE
docs: add search, carousel, and landing page design docs

### DIFF
--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -123,6 +123,9 @@ A component library lives in `design/`. It documents every ready-made UI compone
 | `design/lists.md`      | `browse.html` - divided list layout                 |
 | `design/badges.md`     | Status badges, count chips, category tags           |
 | `design/pagination.md` | `paginate.html` - Previous/Next with HTMX           |
+| `design/search.md`     | HTMX debounced search input with URL push + clear   |
+| `design/carousel.md`   | Alpine.js lightbox carousel with sorl-thumbnail     |
+| `design/landing.md`    | Hero, feature grid, CTA — public landing page       |
 | `design/typography.md` | `markdown.html`, prose, heading scale, link style   |
 | `design/layout.md`     | Base templates, two-column layout, HTMX indicator   |
 | `design/upload.md`     | Multi-file upload widget (Alpine + drag-and-drop)   |

--- a/template/design/carousel.md
+++ b/template/design/carousel.md
@@ -1,0 +1,138 @@
+# Carousel / Lightbox
+
+Pattern built inline per project — no shipped template.
+
+## Overview
+
+An Alpine.js photo carousel with a full-screen lightbox overlay. Thumbnail
+images are rendered server-side with `sorl-thumbnail`; the lightbox receives
+photo URLs via `json_script` to avoid inline data interpolation.
+
+## View
+
+Serialise photo data in the view — never interpolate raw model data into
+Alpine `x-data` attributes:
+
+```python
+photos = list(obj.photos.order_by("-is_cover", "created"))
+photos_data = [{"url": photo.image.url, "pk": photo.pk} for photo in photos]
+context = {"photos": photos, "photos_data": photos_data, ...}
+```
+
+## Template
+
+```html
+{% load heroicons i18n thumbnail %}
+
+{% if photos %}
+  {{ photos_data|json_script:"photos-data" }}
+
+  <div id="photo-gallery"
+       x-data="{
+         open: false,
+         current: 0,
+         photos: [],
+         init() { this.photos = JSON.parse(document.getElementById('photos-data').textContent); },
+         openAt(index) { this.current = index; this.open = true; },
+         prev() { this.current = (this.current - 1 + this.photos.length) % this.photos.length; },
+         next() { this.current = (this.current + 1) % this.photos.length; },
+       }">
+
+    {# Thumbnail grid #}
+    <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+      {% for photo in photos %}
+        <button
+          type="button"
+          class="overflow-hidden rounded-lg border border-zinc-200 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-zinc-700"
+          aria-label="{% translate "View photo" %}"
+          @click="openAt({{ forloop.counter0 }})"
+        >
+          {% thumbnail photo.image "300x200" crop="center" as thumb %}
+            <img
+              src="{{ thumb.url }}"
+              alt=""
+              width="{{ thumb.width }}"
+              height="{{ thumb.height }}"
+              class="w-full object-cover transition-opacity hover:opacity-90"
+              loading="lazy"
+            >
+          {% empty %}
+            <div class="aspect-video bg-zinc-100 dark:bg-zinc-800"></div>
+          {% endthumbnail %}
+        </button>
+      {% endfor %}
+    </div>
+
+    {# Lightbox overlay #}
+    <div
+      x-show="open"
+      x-cloak
+      x-transition
+      role="dialog"
+      aria-modal="true"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
+      @keyup.escape.window="open = false"
+    >
+      <button
+        type="button"
+        class="absolute top-4 right-4 text-white"
+        aria-label="{% translate "Close" %}"
+        @click="open = false"
+      >
+        {% heroicon_outline "x-mark" class="size-8" aria_hidden="true" %}
+      </button>
+
+      <button
+        type="button"
+        class="absolute left-4 text-white disabled:opacity-30"
+        aria-label="{% translate "Previous photo" %}"
+        :disabled="photos.length <= 1"
+        @click="prev()"
+      >
+        {% heroicon_outline "chevron-left" class="size-10" aria_hidden="true" %}
+      </button>
+
+      {# djlint:off H006 — dynamic Alpine src, no thumbnail object available #}
+      <img
+        :src="photos[current]?.url"
+        alt=""
+        class="max-h-[85vh] max-w-[85vw] rounded-lg object-contain shadow-xl"
+      >
+      {# djlint:on #}
+
+      <button
+        type="button"
+        class="absolute right-4 text-white disabled:opacity-30"
+        aria-label="{% translate "Next photo" %}"
+        :disabled="photos.length <= 1"
+        @click="next()"
+      >
+        {% heroicon_outline "chevron-right" class="size-10" aria_hidden="true" %}
+      </button>
+
+      <span class="absolute bottom-4 text-sm text-white/70">
+        <span x-text="current + 1"></span> / <span x-text="photos.length"></span>
+      </span>
+    </div>
+  </div>
+{% endif %}
+```
+
+## Notes
+
+- `json_script` is required — never interpolate `photo.image.url` directly into
+  `x-data`. Django's `json_script` filter escapes the data safely.
+- Always use `{{ thumb.width }}` and `{{ thumb.height }}` from the
+  `sorl-thumbnail` object for the grid thumbnails — never hardcode dimensions.
+- The `{% empty %}` block inside `{% thumbnail %}` handles the case where no
+  image file is set on the model instance.
+- The lightbox `<img>` uses a dynamic Alpine `:src` binding, so no
+  `{% thumbnail %}` object is available. `djlint:off H006` suppresses the
+  missing-width/height lint warning for that element only.
+- Keyboard navigation: `@keyup.escape.window` closes the overlay; prev/next
+  buttons handle arrow-key navigation via `@click`. Add `@keyup.arrowleft.window`
+  and `@keyup.arrowright.window` if keyboard navigation of photos is required.
+- Accessibility: all buttons have `aria-label`, the overlay has `role="dialog"`
+  and `aria-modal="true"`, thumbnail images use `alt=""` (decorative).
+- `x-cloak` requires the Tailwind `x-cloak { display: none }` rule. This is
+  already present in the generated project's base CSS.

--- a/template/design/landing.md
+++ b/template/design/landing.md
@@ -1,0 +1,119 @@
+# Landing Page
+
+A public-facing marketing page with a hero, feature highlights, and call-to-action.
+Build inline — no shipped template.
+
+## Base template
+
+Landing pages typically do not share the authenticated app shell. Use a
+dedicated base or extend `base.html` with an empty `{% block sidebar %}`:
+
+```html
+{% extends "base.html" %}
+
+{% block content %}
+  ...
+{% endblock content %}
+```
+
+If the landing page should have no sidebar at all, override or omit the sidebar
+block (see `design/layout.md`).
+
+## Hero section
+
+```html
+<section class="py-20 sm:py-32">
+  <div class="mx-auto max-w-3xl px-4 text-center sm:px-6">
+    <h1 class="text-4xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50 sm:text-6xl">
+      {% translate "Headline goes here" %}
+    </h1>
+    <p class="mt-6 text-lg leading-8 text-zinc-600 dark:text-zinc-400">
+      {% translate "A concise sub-headline describing the value proposition." %}
+    </p>
+    <div class="mt-10 flex items-center justify-center gap-4">
+      <a href="{% url 'account_signup' %}" class="btn btn-primary">
+        {% translate "Get started" %}
+      </a>
+      <a href="#features" class="btn btn-secondary">
+        {% translate "Learn more" %}
+      </a>
+    </div>
+  </div>
+</section>
+```
+
+## Feature grid
+
+```html
+<section id="features" class="py-16 sm:py-24">
+  <div class="mx-auto max-w-5xl px-4 sm:px-6">
+    <h2 class="text-center text-2xl font-bold text-zinc-900 dark:text-zinc-50 sm:text-3xl">
+      {% translate "Why choose us" %}
+    </h2>
+    <div class="mt-12 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+      {# Repeat for each feature #}
+      <div class="rounded-xl border border-(--color-border) bg-(--color-surface) p-6">
+        {% heroicon_outline "bolt" class="size-8 text-primary-600 dark:text-primary-400" aria_hidden="true" %}
+        <h3 class="mt-4 font-semibold text-zinc-900 dark:text-zinc-50">
+          {% translate "Feature name" %}
+        </h3>
+        <p class="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+          {% translate "Short description of what this feature does." %}
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+```
+
+## CTA section
+
+```html
+<section class="py-16 sm:py-24">
+  <div class="mx-auto max-w-2xl px-4 text-center sm:px-6">
+    <h2 class="text-2xl font-bold text-zinc-900 dark:text-zinc-50 sm:text-3xl">
+      {% translate "Ready to get started?" %}
+    </h2>
+    <p class="mt-4 text-zinc-600 dark:text-zinc-400">
+      {% translate "Join today and start doing the thing." %}
+    </p>
+    <a href="{% url 'account_signup' %}" class="btn btn-primary mt-8">
+      {% translate "Create your account" %}
+    </a>
+  </div>
+</section>
+```
+
+## View
+
+Landing pages are typically public (`@require_safe` only, no `@login_required`):
+
+```python
+from django.template.response import TemplateResponse
+from django.views.decorators.http import require_safe
+
+from myapp.http.request import HttpRequest
+
+
+@require_safe
+def landing(request: HttpRequest) -> TemplateResponse:
+    return TemplateResponse(request, "landing.html", {})
+```
+
+Wire it in `config/urls.py`:
+
+```python
+path("", views.landing, name="landing"),
+```
+
+## HTMX / Alpine integration
+
+If sections load lazily or contain interactive elements, add HTMX or Alpine
+attributes as needed. Keep the landing page lightweight — defer heavy dynamic
+content to authenticated views.
+
+## Design tokens
+
+Use `--color-surface` / `--color-border` for cards. Use the primary colour for
+CTAs (`btn-primary`). Hero text uses the standard Tailwind zinc scale for
+light/dark compatibility.

--- a/template/design/search.md
+++ b/template/design/search.md
@@ -1,0 +1,115 @@
+# Search
+
+Template: `templates/search.html` (build per project — no shipped template)
+CSS: none required beyond `form-input`
+
+## Overview
+
+The project ships a `SearchMiddleware` that adds `request.search` (a
+`SearchDetails` instance) to every request. Use it in views and templates to
+drive debounced, HTMX-powered search that updates the URL bar without a full
+page reload.
+
+## `request.search` API
+
+| Expression | Type | Description |
+|---|---|---|
+| `request.search.value` | `str` | The current search query (stripped, max 200 chars) |
+| `request.search.qs` | `str` | `?search=<value>` or `""` if empty |
+| `bool(request.search)` | `bool` | `True` if a non-empty search query is present |
+| `str(request.search)` | `str` | Same as `.value` |
+
+The middleware reads from `GET["search"]`. Override `param` if you need a
+different query-string key.
+
+## View
+
+Pass `request.search` to the queryset filter and into context:
+
+```python
+from myapp.db.search import Searchable  # if model uses FTS
+
+@require_safe
+@login_required
+def item_list(request: HttpRequest) -> TemplateResponse:
+    qs = Item.objects.all()
+    if request.search:
+        qs = qs.search(request.search.value)
+    return render_paginated_response(
+        request,
+        "myapp/item_list.html",
+        qs,
+        target="pagination",
+        partial="pagination",
+    )
+```
+
+## Template
+
+The search input uses HTMX to fire on every keystroke (debounced 300 ms) and
+pushes the new URL into the browser history. The pagination `<div>` is the swap
+target so only the list updates — the header and search bar stay in place.
+
+```html
+{% load i18n %}
+
+{% include "header.html" with title=_("Items") %}
+
+<div class="mt-4 flex items-center gap-3">
+  <div class="relative flex-1 sm:max-w-xs">
+    <input
+      type="search"
+      name="search"
+      value="{{ request.search.value }}"
+      placeholder="{% translate "Search…" %}"
+      autocomplete="off"
+      class="form-input w-full"
+      hx-get="{{ request.path }}"
+      hx-trigger="input changed delay:300ms, search"
+      hx-target="#pagination"
+      hx-push-url="true"
+      hx-include="[name='search']"
+    >
+    {% if request.search %}
+      <a
+        href="{{ request.path }}"
+        class="absolute inset-y-0 right-0 flex items-center px-3 text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200"
+        aria-label="{% translate "Clear search" %}"
+        hx-get="{{ request.path }}"
+        hx-target="#pagination"
+        hx-push-url="{{ request.path }}"
+      >
+        {% heroicon_mini "x-mark" class="size-4" aria_hidden="true" %}
+      </a>
+    {% endif %}
+  </div>
+</div>
+
+{% partialdef pagination inline %}
+  {% fragment "paginate.html" %}
+    ...
+  {% endfragment %}
+{% endpartialdef pagination %}
+```
+
+### Notes
+
+- `hx-trigger="input changed delay:300ms, search"` debounces typing and also
+  fires immediately when the browser's built-in search clear button is clicked.
+- `hx-push-url="true"` keeps the URL bar in sync so users can share or bookmark
+  search results.
+- The clear button (`x-mark`) links back to `request.path` (no query string).
+  Its `hx-push-url` attribute uses `request.path` directly so the URL bar clears.
+- `hx-include="[name='search']"` is not needed when the input is the trigger
+  element — HTMX includes it automatically — but is required if the clear
+  button fires the request from a sibling element.
+
+## Integration with `render_paginated_response`
+
+`render_paginated_response` sets `pagination_target` in context and matches the
+`HX-Target` header to decide whether to render the full page or the named
+partial. The search input targets `#pagination`, which is the `<div id="pagination">`
+that `paginate.html` renders inside `{% partialdef pagination %}`.
+
+No additional view logic is needed: on the first load HTMX is not involved,
+on subsequent searches only the pagination partial is re-rendered.


### PR DESCRIPTION
## Summary

Adds three new design system docs:

**`design/search.md`** (#114): Documents the HTMX debounced search input pattern, integrating with the existing `SearchMiddleware` / `request.search` API. Covers view setup, the `hx-trigger` debounce, `hx-push-url`, clear button, and how it hooks into `render_paginated_response`.

**`design/carousel.md`** (#116): Documents the Alpine.js lightbox carousel pattern for photo galleries. Uses `sorl-thumbnail` for the grid and `json_script` for safe data injection. Includes WCAG accessibility attributes (`role="dialog"`, `aria-modal`, `aria-label` on all buttons), keyboard nav, and notes the `djlint:off H006` exception for the Alpine-bound lightbox `<img>`.

**`design/landing.md`** (#119): Documents the public landing page pattern with hero, feature grid, and CTA sections. Covers view setup (`@require_safe`, no login required), base template choice, and HTMX/Alpine integration guidance.

Also updates the design system table in `AGENTS.md.jinja` with all three new docs.

Closes #114, #116, #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)