### PR TITLE
feat: add MoneyWidget partial and CSS for django-money support

### DIFF
--- a/template/design/forms.md
+++ b/template/design/forms.md
@@ -113,22 +113,12 @@ Built-in widgets and their partials:
 
 ### Custom Widget Partials
 
-If you add a custom widget — from a third-party package (e.g. `django-money`,
-`django-phonenumber-field`) or from within this project — **you must add a
-matching `{% partialdef %}` block to `templates/form/field.html`**. Without it
-the field renders nothing, with no error.
+If you add a custom widget — from a third-party package or from within this
+project — **you must add a matching `{% partialdef %}` block to
+`templates/form/field.html`**. Without it the field renders nothing, with no
+error.
 
-The partial name is the widget's class name, lowercased. For example, if
-`django-money` uses a widget class named `MoneyWidget`, the partial name is
-`moneywidget`:
-
-```html
-{# django-money MoneyWidget #}
-{% partialdef moneywidget %}
-  {% partial label %}
-  {% render_field field class="form-input" %}  {# adjust markup to suit the widget #}
-{% endpartialdef %}
-```
+The partial name is the widget's class name, lowercased.
 
 Steps for any custom widget:
 
@@ -140,6 +130,26 @@ Steps for any custom widget:
    to keep label/error/help-text rendering consistent with built-in widgets.
 4. Test by rendering the field with `{{ field.as_field_group }}` and verifying
    the output is not empty.
+
+#### Example: `django-money` `MoneyWidget`
+
+`MoneyWidget` is a `MultiWidget` that combines an amount `TextInput` and a
+currency `Select`. The partial and CSS are pre-built in the template:
+
+```html
+{# templates/form/field.html — already present #}
+{% partialdef moneywidget %}
+  {% partial label %}
+  <div class="money-widget">
+    {% render_field field %}
+  </div>
+{% endpartialdef %}
+```
+
+The `.money-widget` class in `tailwind/forms.css` stacks the two sub-widgets
+vertically on mobile and side-by-side on `sm+`, giving both the same styling as
+`form-input`/`form-select`. No additional configuration is needed beyond
+installing `django-money` and using `MoneyField` in the model.
 
 ## CSS Classes
 

--- a/template/tailwind/forms.css
+++ b/template/tailwind/forms.css
@@ -37,6 +37,46 @@
         }
     }
 
+    /* django-money MoneyWidget — responsive amount + currency layout */
+    .money-widget {
+        display: inline-flex;
+        flex-direction: column;
+        gap: theme("spacing.2");
+
+        @media (min-width: theme("screens.sm")) {
+            flex-direction: row;
+            align-items: stretch;
+        }
+
+        input,
+        select {
+            width: theme("spacing.36");
+            background: var(--color-surface);
+            color: var(--color-text);
+            border-radius: var(--radius-lg);
+            border: 1px solid var(--color-border);
+            padding: theme("padding.2") theme("padding.3");
+            transition: border-color 200ms ease, box-shadow 200ms ease;
+
+            @variant focus {
+                border-color: var(--color-primary-500);
+                box-shadow: 0 0 0 3px color-mix(in oklch, var(--color-primary-500) 10%, transparent);
+                outline: none;
+            }
+
+            @variant dark {
+                background: var(--color-zinc-800);
+                border-color: var(--color-zinc-600);
+                color: var(--color-zinc-200);
+
+                @variant focus {
+                    border-color: var(--color-primary-400);
+                    box-shadow: 0 0 0 3px color-mix(in oklch, var(--color-primary-500) 20%, transparent);
+                }
+            }
+        }
+    }
+
     /* search inputs */
 
     input[type="search"]::-webkit-search-decoration,

--- a/template/templates/form/field.html
+++ b/template/templates/form/field.html
@@ -114,3 +114,11 @@
   {% partial label %}
   {% render_field field class="form-multiselect" %}
 {% endpartialdef %}
+
+{# django-money MoneyWidget (amount + currency select) #}
+{% partialdef moneywidget %}
+  {% partial label %}
+  <div class="money-widget">
+    {% render_field field %}
+  </div>
+{% endpartialdef %}


### PR DESCRIPTION
## Summary

- Adds `{% partialdef moneywidget %}` to `templates/form/field.html` so `MoneyField` forms render correctly via `{{ field.as_field_group }}` without `TemplateDoesNotExist: moneywidget`
- Adds `.money-widget` CSS to `tailwind/forms.css`: stacks amount input and currency select vertically on mobile, side-by-side on `sm+`, styled to match `form-input`/`form-select`
- Updates `design/forms.md` custom widget section with a concrete `django-money` example showing both the partial and how the CSS works

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)