### PR TITLE
feat: add deploy-config recipe to keep Helm chart and CI secrets in sync

### DIFF
--- a/skills/djstudio/launch.md
+++ b/skills/djstudio/launch.md
@@ -409,6 +409,12 @@ just gh-set-secrets
 This pushes `KUBECONFIG_BASE64` and `HELM_VALUES_SECRET` to the GitHub repository secrets.
 Tell the user what was pushed and confirm with `gh secret list`.
 
+> **After the initial deploy:** whenever you change a config value in
+> `values.secret.yaml` (e.g. admin email, feature flag), run `just deploy-config`
+> instead of `just gh-set-secrets` and `just helm site` separately. It pushes the
+> secrets to GitHub **and** applies the updated Helm chart to the cluster in one step,
+> keeping CI and the running cluster in sync.
+
 ---
 
 ## Step 6 — First deploy

--- a/template/justfile
+++ b/template/justfile
@@ -171,6 +171,13 @@ gh-set-secrets:
     gh secret set HELM_VALUES_SECRET < helm/site/values.secret.yaml
     gh secret list
 
+# Push updated values.secret.yaml to GitHub AND apply to the cluster atomically.
+# Use this whenever you change a config value (admin email, feature flag, etc.)
+# to keep CI secrets and the running cluster in sync.
+[group('deployment')]
+deploy-config: gh-set-secrets
+    just helm site
+
 # Install or upgrade a Helm chart, e.g. 'just helm site' or 'just helm observability'
 [group('deployment')]
 helm chart="site":


### PR DESCRIPTION
## Summary

- Adds a `deploy-config` just recipe to the generated justfile that runs `gh-set-secrets` then `helm site` atomically
- Documents the pattern in launch wizard Step 5 so users know to use `just deploy-config` for config changes after initial deploy

`just gh-set-secrets` and `just helm site` remain available individually, but `just deploy-config` is the recommended single command when changing a config value in `values.secret.yaml`.

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)