### PR TITLE
fix: do not overwrite image tag with hardcoded SHA after first deploy

### DIFF
--- a/skills/djstudio/launch.md
+++ b/skills/djstudio/launch.md
@@ -462,20 +462,6 @@ Watch the run:
 gh run watch
 ```
 
-When the workflow completes successfully, read the actual deployed image tag from the
-cluster and update `values.secret.yaml` so that `just helm site` works correctly for
-future manual deploys:
-
-```bash
-just kube get deployment django-app -o jsonpath='{.spec.template.spec.containers[0].image}'
-```
-
-Update `image` in `values.secret.yaml` with this value, then re-push the secret:
-
-```bash
-just gh-set-secrets
-```
-
 Then show pod status:
 ```bash
 just kube get pods


### PR DESCRIPTION
## Summary

- Removes the step from the launch wizard (Step 6c) that read the deployed image SHA from the cluster and wrote it back to `values.secret.yaml`

The `:main` tag is correct and should stay as-is. `just gh deploy` always overrides the image at deploy time via `--set image=$IMAGE` with a fresh SHA, so `values.secret.yaml`'s value is only a fallback. Overwriting it with a pinned SHA causes silent rollbacks on subsequent `just helm site` runs (e.g. config-only changes).

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)