### PR TITLE
feat: prompt for Sentry/OpenTelemetry config and offer observability node in launch wizard

### DIFF
--- a/skills/djstudio/launch.md
+++ b/skills/djstudio/launch.md
@@ -393,6 +393,27 @@ Tell the user which URL was chosen.
 
 **Meta author, description, keywords** — prompt for each, allow empty to skip.
 
+### Observability credentials (conditional)
+
+Check `pyproject.toml` for the presence of `sentry-sdk` and `opentelemetry-sdk` to detect
+which observability features are enabled in this project.
+
+**If `sentry-sdk` is present** and `secrets.sentryUrl` is empty:
+> Sentry is enabled in this project. Paste your Sentry DSN URL
+> (Sentry project → Settings → Client Keys → DSN):
+>
+> Press Enter to skip and configure later.
+
+Set `secrets.sentryUrl` if provided.
+
+**If `opentelemetry-sdk` is present** and `secrets.openTelemetryUrl` is empty:
+> OpenTelemetry is enabled in this project. Paste your OTLP collector endpoint URL
+> (e.g. `https://otel.yourdomain.com`):
+>
+> Press Enter to skip and configure later.
+
+Set `secrets.openTelemetryUrl` if provided.
+
 ### Write the file
 
 Write all values to `helm/site/values.secret.yaml`, preserving any values that were
@@ -497,3 +518,34 @@ just kube describe pod <failing-pod>
 just kube logs <failing-pod>
 ```
 Diagnose and help the user fix the issue before declaring success.
+
+---
+
+## Step 7 — Observability node (conditional)
+
+Only proceed with this step if `opentelemetry-sdk` is present in `pyproject.toml`.
+
+Once all site pods are Running, ask:
+
+> OpenTelemetry is enabled in this project. Do you want to deploy the observability
+> node now (Grafana + Prometheus + Loki)? (y/n)
+>
+> (This is optional — you can deploy it later with `just helm observability`.)
+
+If **no**, tell the user:
+> You can deploy the observability stack at any time by running `just helm observability`.
+
+If **yes**, first check `helm/observability/values.secret.yaml`:
+- If it does not exist, copy from example:
+  ```bash
+  cp helm/observability/values.secret.yaml.example helm/observability/values.secret.yaml
+  ```
+- Read the file and prompt for any values still set to `CHANGE_ME`.
+
+Then deploy:
+```bash
+just helm observability
+```
+
+Wait for completion. Show pod status and confirm the Grafana ingress is accessible at
+`https://grafana.<domain>` once DNS propagates.


### PR DESCRIPTION
## Summary

- Adds conditional prompts in Step 4 (Helm secrets) for `secrets.sentryUrl` (Sentry DSN) and `secrets.openTelemetryUrl` (OTLP endpoint), triggered by detecting `sentry-sdk` / `opentelemetry-sdk` in `pyproject.toml`
- Adds Step 7 (observability node) that offers to deploy Grafana + Prometheus + Loki via `just helm observability` when OpenTelemetry is enabled, with prompts for any missing `values.secret.yaml` values

Both steps are conditional — projects without these features skip them entirely.

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)