### PR TITLE
docs: clarify static/vendor/ is for third-party libraries only

### DIFF
--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -148,7 +148,7 @@ A component library lives in `design/`. It documents every ready-made UI compone
 
 Always vendor the latest stable minified library file directly into the project:
 
-- Place vendored files under `static/vendor/` with the version in the filename (e.g. `static/vendor/htmx.2.0.4.min.js`).
+- Place third-party vendored files under `static/vendor/` with the version in the filename (e.g. `static/vendor/htmx.2.0.4.min.js`).
 - Reference them with Django's `static` template tag in templates.
 - See the existing HTMX and AlpineJS files in `static/vendor/` as examples.
 


### PR DESCRIPTION
## Summary

- Changes "Place vendored files" to "Place third-party vendored files" in `template/AGENTS.md.jinja` to make it unambiguous that `static/vendor/` is only for external libraries, not project-specific scripts.

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)