### PR TITLE
feat: add {% block scripts %} and move hxIndicator to Alpine.data

### DIFF
--- a/template/templates/base.html
+++ b/template/templates/base.html
@@ -12,21 +12,7 @@
     <script src="{% static 'vendor/alpine-3.15.2.min.js' %}" defer></script>
   </head>
   <body>
-    <div
-      id="hx-indicator"
-      x-data="{ width: 0 }"
-      x-init="
-        setInterval(() => {
-          if ($el.classList.contains('htmx-request')) {
-            width = width + (Math.random() / 100) + 1;
-            width = width > 30 ? -30 : width;
-          } else {
-            width = 0;
-          }
-          $el.style.width = width > 0 ? `${10 + width * 90}%` : '0px';
-        }, 36);
-      "
-    ></div>
+    <div id="hx-indicator" x-data="hxIndicator"></div>
     {% include "messages.html" %}
     {% cookie_banner %}
     {% include "navbar.html" %}
@@ -34,6 +20,26 @@
       {% block content %}
       {% endblock content %}
     </main>
+    {% block scripts %}
+    <script>
+      document.addEventListener('alpine:init', () => {
+        Alpine.data('hxIndicator', () => ({
+          width: 0,
+          init() {
+            setInterval(() => {
+              if (this.$el.classList.contains('htmx-request')) {
+                this.width = this.width + (Math.random() / 100) + 1;
+                this.width = this.width > 30 ? -30 : this.width;
+              } else {
+                this.width = 0;
+              }
+              this.$el.style.width = this.width > 0 ? `${10 + this.width * 90}%` : '0px';
+            }, 36);
+          },
+        }));
+      });
+    </script>
     [[ HOOK:pwa-sw ]]
+    {% endblock scripts %}
   </body>
 </html>


### PR DESCRIPTION
## Summary

- Collapses the verbose inline `x-data`/`x-init` on `#hx-indicator` into a single `x-data="hxIndicator"` attribute.
- Moves the `hxIndicator` logic into `Alpine.data()` defined inside a new `{% block scripts %}` block at the foot of `<body>`.
- The `[[ HOOK:pwa-sw ]]` PWA service-worker marker is placed inside the same block so both the Alpine component and the optional PWA script are in one extensible location.
- Child templates can now append per-page Alpine components or other footer scripts cleanly with `{{ block.super }}`.

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)