### PR TITLE
fix(a11y): add i18n, aria-live, and aria-label to paginate.html

### DIFF
--- a/template/templates/paginate.html
+++ b/template/templates/paginate.html
@@ -1,5 +1,6 @@
+{% load i18n %}
 {% with has_other_pages=page.has_other_pages %}
-  <div id="{{ pagination_target }}">
+  <div id="{{ pagination_target }}" aria-live="polite" aria-atomic="true">
     {% if has_other_pages %}
       <div class="pb-3">
         {% partial links %}
@@ -17,7 +18,7 @@
 {% partialdef links %}
   <nav
     role="navigation"
-    aria-label="Pagination"
+    aria-label="{% translate "Pagination" %}"
     hx-swap="outerHTML show:window:top"
     hx-target="#{{ pagination_target }}"
   >
@@ -26,32 +27,32 @@
         {% if page.has_previous %}
           <a
             href="{{ request.path }}{% querystring page=page.previous_page_number %}"
-            aria-label="Previous Page"
-            title="Previous Page"
+            aria-label="{% translate "Previous Page" %}"
+            title="{% translate "Previous Page" %}"
             class="link"
-          >Previous</a>
+          >{% translate "Previous" %}</a>
         {% else %}
           <span
             class="cursor-not-allowed text-muted-600 dark:text-muted-300"
-            title="First Page"
-            aria-label="First Page"
-          >Previous</span>
+            title="{% translate "First Page" %}"
+            aria-label="{% translate "First Page" %}"
+          >{% translate "Previous" %}</span>
         {% endif %}
       </li>
       <li>
         {% if page.has_next %}
           <a
             href="{{ request.path }}{% querystring page=page.next_page_number %}"
-            aria-label="Next Page"
-            title="Next Page"
+            aria-label="{% translate "Next Page" %}"
+            title="{% translate "Next Page" %}"
             class="link"
-          >Next</a>
+          >{% translate "Next" %}</a>
         {% else %}
           <span
             class="cursor-not-allowed text-muted-600 dark:text-muted-300"
-            title="Last Page"
-            aria-label="Last Page"
-          >Next</span>
+            title="{% translate "Last Page" %}"
+            aria-label="{% translate "Last Page" %}"
+          >{% translate "Next" %}</span>
         {% endif %}
       </li>
     </ul>


### PR DESCRIPTION
## Summary

- Add `{% load i18n %}` so `{% translate %}` tags work
- Add `aria-live="polite"` and `aria-atomic="true"` to the outer wrapper so screen readers announce page changes after HTMX swaps
- Add `aria-label="{% translate "Pagination" %}"` to the `<nav>` landmark
- Wrap all visible text and `aria-label`/`title` attribute values in `{% translate %}`

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)