### PR TITLE
fix(a11y): add aria_hidden to dismiss icon in messages.html

### DIFF
--- a/template/templates/messages.html
+++ b/template/templates/messages.html
@@ -19,7 +19,7 @@
                         aria-label="{% translate "Dismiss" %}"
                         @click="show = false"
                         class="shrink-0 rounded-lg transition-colors hover:bg-black/10 dark:hover:bg-white/10 cursor-pointer">
-                        {% heroicon_mini "x-mark" class="size-4" %}
+                        {% heroicon_mini "x-mark" class="size-4" aria_hidden="true" %}
                     </button>
                 </li>
             {% endfor %}


### PR DESCRIPTION
## Summary

- Add `aria_hidden="true"` to the `{% heroicon_mini "x-mark" %}` in the dismiss button

The button already has `aria-label="Dismiss"` which provides its accessible name. The icon is purely decorative here, so `aria_hidden="true"` prevents screen readers from announcing the SVG icon name redundantly alongside the button label.

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)