### PR TITLE
fix(a11y): add role=region and aria-label to cookie_banner.html

### DIFF
--- a/template/templates/cookie_banner.html
+++ b/template/templates/cookie_banner.html
@@ -4,6 +4,8 @@
     <div
       class="flex fixed bottom-0 z-50 justify-center w-full text-white opacity-90 bg-muted-900 dark:bg-muted-800"
       id="{{ target }}"
+      role="region"
+      aria-label="{% translate "Cookie consent" %}"
     >
       <div class="flex justify-center p-3 w-full text-center md:w-3/4">
         <div class="space-y-3">


### PR DESCRIPTION
## Summary

- Add `role="region"` and `aria-label="{% translate "Cookie consent" %}"` to the outer wrapper `<div>`

Without a landmark role, the cookie banner's content existed outside any landmark region — an axe-core violation. This makes the banner a named landmark that screen readers can navigate to and announce as a distinct region.

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)