### PR TITLE
feat: extract hxIndicator to indicator.js, fix Alpine loading order, add aria-busy

### DIFF
--- a/template/static/indicator.js
+++ b/template/static/indicator.js
@@ -1,0 +1,16 @@
+document.addEventListener('alpine:init', () => {
+  Alpine.data('hxIndicator', () => ({
+    width: 0,
+    init() {
+      setInterval(() => {
+        if (this.$el.classList.contains('htmx-request')) {
+          this.width = this.width + (Math.random() / 100) + 1;
+          this.width = this.width > 30 ? -30 : this.width;
+        } else {
+          this.width = 0;
+        }
+        this.$el.style.width = this.width > 0 ? `${10 + this.width * 90}%` : '0px';
+      }, 36);
+    },
+  }));
+});

--- a/template/templates/base.html
+++ b/template/templates/base.html
@@ -21,25 +21,14 @@
       {% endblock content %}
     </main>
     {% block scripts %}
+    <script src="{% static 'indicator.js' %}"></script>
     <script>
-      document.addEventListener('alpine:init', () => {
-        Alpine.data('hxIndicator', () => ({
-          width: 0,
-          init() {
-            setInterval(() => {
-              if (this.$el.classList.contains('htmx-request')) {
-                this.width = this.width + (Math.random() / 100) + 1;
-                this.width = this.width > 30 ? -30 : this.width;
-              } else {
-                this.width = 0;
-              }
-              this.$el.style.width = this.width > 0 ? `${10 + this.width * 90}%` : '0px';
-            }, 36);
-          },
-        }));
+      document.addEventListener('htmx:beforeRequest', (evt) => {
+        evt.detail.target?.setAttribute('aria-busy', 'true');
       });
-    </script>
-    <script>
+      document.addEventListener('htmx:afterRequest', (evt) => {
+        evt.detail.target?.removeAttribute('aria-busy');
+      });
       if (typeof navigator.serviceWorker !== 'undefined') {
         navigator.serviceWorker.register('{% static "service-worker.js" %}')
       }


### PR DESCRIPTION
## Summary

- Extract the `hxIndicator` Alpine component from the inline `<script>` block in `base.html` into `static/indicator.js`
- Load `indicator.js` via `<script src="...">` in `{% block scripts %}` **without** `defer` — this is the correct loading order for `Alpine.data()` registration (see below)
- Add `htmx:beforeRequest` / `htmx:afterRequest` listeners that toggle `aria-busy="true"` on the HTMX swap target so screen readers can announce loading state

### Why no `defer` on component scripts

Alpine itself loads with `defer` in `<head>`. Scripts at the bottom of `<body>` without `defer` execute before deferred scripts fire. By the time Alpine's deferred script dispatches `alpine:init`, the `Alpine.data('hxIndicator', ...)` registration from `indicator.js` is already in place. Using `defer` on component scripts in `<head>` would make execution order relative to Alpine ambiguous.

Closes #156
Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)