### PR TITLE
fix: backup/restore bugs — pinned aws-cli image, gunzip in right container, nodeSelector

### DIFF
--- a/template/docs/CronJobs.md
+++ b/template/docs/CronJobs.md
@@ -103,6 +103,20 @@ All cron jobs use `concurrencyPolicy: Replace` — if a previous run is still ex
 when the next schedule fires, the old job is terminated and replaced. Design commands to
 be safe to interrupt (idempotent enqueue calls, no long transactions).
 
+## Node Scheduling
+
+All batch workloads — CronJobs, one-off restore pods, and Helm release jobs — must run
+on the `jobrunner` node. This is enforced via `nodeSelector` in every pod spec:
+
+```yaml
+nodeSelector:
+  role: jobrunner
+```
+
+This is already set in all chart templates (`cronjobs.yaml`, `postgres-backup-cronjob.yaml`,
+`release-job.yaml`) and in the `db-restore` pod created by `just rdb-restore`. When adding
+any new one-off job or CronJob, always include this selector.
+
 ## Observing Jobs
 
 ```bash

--- a/template/helm/site/scripts/db_download.sh
+++ b/template/helm/site/scripts/db_download.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 
 aws --endpoint-url "${BACKUP_ENDPOINT}" s3 cp \
   "s3://${BACKUP_BUCKET}/${FILENAME}" /backup/dump.sql.gz
-gunzip /backup/dump.sql.gz
-echo "Download complete: $(du -h /backup/dump.sql | cut -f1)"
+echo "Download complete: $(du -h /backup/dump.sql.gz | cut -f1)"

--- a/template/helm/site/scripts/db_restore.sh
+++ b/template/helm/site/scripts/db_restore.sh
@@ -7,5 +7,5 @@ echo "Clearing database..."
 psql -h postgres -U postgres -d postgres \
   -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT ALL ON SCHEMA public TO postgres;"
 echo "Restoring from dump..."
-psql -h postgres -U postgres -d postgres < /backup/dump.sql
+gunzip -c /backup/dump.sql.gz | psql -h postgres -U postgres -d postgres
 echo "Restore complete."

--- a/template/helm/site/values.yaml.jinja
+++ b/template/helm/site/values.yaml.jinja
@@ -109,7 +109,7 @@ backup:
   enabled: false
   schedule: "0 3 * * *"
   retention: 7
-  awsCliImage: "amazon/aws-cli:2"
+  awsCliImage: "amazon/aws-cli:2.34.11"
 
 # PostgreSQL major-version upgrade (disabled by default)
 pgUpgrade:

--- a/template/just/db_restore.sh.jinja
+++ b/template/just/db_restore.sh.jinja
@@ -29,9 +29,11 @@ metadata:
   name: db-restore
 spec:
   restartPolicy: Never
+  nodeSelector:
+    role: jobrunner
   initContainers:
     - name: download
-      image: amazon/aws-cli:2
+      image: amazon/aws-cli:2.34.11
       command: ["/bin/bash", "/scripts/db_download.sh"]
       env:
         - name: FILENAME


### PR DESCRIPTION
## Summary

- Pin `awsCliImage` to `amazon/aws-cli:2.34.11` in `values.yaml.jinja` and `db_restore.sh.jinja` — the `:2` tag does not exist on Docker Hub and causes `ErrImagePull`
- Remove `gunzip` from `db_download.sh` — the aws-cli image has no gunzip binary; keep the file as `.sql.gz`
- Pipe through `gunzip -c` in `db_restore.sh` — the postgres (Debian) image has gunzip available
- Add `nodeSelector: role: jobrunner` to the `db-restore` pod spec in `db_restore.sh.jinja`
- Document the jobrunner nodeSelector rule in `docs/CronJobs.md` as mandatory for all batch workloads

Fixes #170, #171, #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)