### PR TITLE
fix: remove instruction to copy skills to ~/.claude/commands/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,14 +143,6 @@ The `/djstudio` skill uses a thin dispatcher (`skills/djstudio.md`) that routes 
 
 Command files live in `skills/` at the repo root and are copied to `.claude/commands/` in the generated project by the post-gen hook (`install_skills()`). They are always tracked in git — no `git add -f` needed.
 
-**Copying to global commands:**
-
-After editing any djstudio command file, copy it to `~/.claude/commands/` if you want the change reflected in the global command registry:
-
-```bash
-cp skills/djstudio.md ~/.claude/commands/djstudio.md
-```
-
 **Adding new subcommand files:**
 
 Create the file under `skills/djstudio/<subcommand>.md`. No `cookiecutter.json` change is needed — the post-gen hook copies the entire `skills/` tree verbatim.


### PR DESCRIPTION
## Summary

- Remove the "Copying to global commands" section from `AGENTS.md`

The removed section instructed agents to `cp skills/djstudio.md ~/.claude/commands/djstudio.md` after editing any skill file. This caused skills to accumulate at user level (`~/.claude/commands/`), making them appear twice in Claude Code's skill list — once from the project's `.claude/commands/` and once from `~/.claude/commands/`.

Skills are project-scoped. The post-gen hook (`install_skills()`) already installs them correctly to `.claude/commands/` inside the generated project. There is no reason to copy them to the user-level commands directory.

Fixes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)