### PR TITLE
docs: Fix partialdef inline usage in HTMX and form patterns

### DIFF
--- a/template/docs/Django-Templates.md
+++ b/template/docs/Django-Templates.md
@@ -29,7 +29,11 @@ The `{% block scripts %}` block is rendered just before `</body>` — use it for
 
 ## partialdef / partial
 
-`partialdef` ([built into Django 6](https://docs.djangoproject.com/en/6.0/ref/templates/language/#template-partials)) defines a named fragment inside a template. `partial` renders it. This is the primary mechanism for HTMX partial swaps.
+`partialdef` ([built into Django 6](https://docs.djangoproject.com/en/6.0/ref/templates/language/#template-partials)) defines a named fragment inside a template. `partial` renders a previously defined fragment by name. This is the primary mechanism for HTMX partial swaps.
+
+Use `inline` when the partial IS the content — i.e. the block should render in place on a full-page load AND be extractable by `render_partial_response` for HTMX swaps. Without `inline`, `{% partialdef %}` defines the fragment but does not render it — you need a separate `{% partial name %}` call to render it.
+
+**Page-level template (use `inline`):**
 
 ```html
 <!-- myapp/items_list.html -->
@@ -37,18 +41,20 @@ The `{% block scripts %}` block is rendered just before `</body>` — use it for
 
 {% block content %}
   <div id="item-list">
-    {% partial item-list %}
+    {% partialdef item-list inline %}
+      {% for item in items %}
+        <p>{{ item.name }}</p>
+      {% endfor %}
+    {% endpartialdef %}
   </div>
 {% endblock content %}
-
-{% partialdef item-list %}
-  {% for item in items %}
-    <p>{{ item.name }}</p>
-  {% endfor %}
-{% endpartialdef %}
 ```
 
-On an HTMX request targeting `#item-list`, `render_partial_response` returns only the `item-list` partial. On a full-page load the whole template renders. See `docs/HTMX.md` for the view-side pattern.
+On an HTMX request targeting `#item-list`, `render_partial_response` returns only the `item-list` partial. On a full-page load `inline` renders the block in place. See `docs/HTMX.md` for the view-side pattern.
+
+**Component template (no `inline`):**
+
+Component templates such as `browse.html`, `paginate.html`, and `sidebar.html` define partials without `inline` because they are always rendered via `{% fragment %}` or `{% partial %}` — never directly. The caller controls what gets rendered.
 
 ## fragment Tag
 

--- a/template/docs/HTMX.md
+++ b/template/docs/HTMX.md
@@ -105,7 +105,7 @@ def my_form_view(request):
     )
 ```
 
-The template defines a `{% partialdef form %}` block that contains just the form markup. On a full-page load the entire template renders; on an HTMX form submit only the `form` partial is returned and swapped in.
+The template defines a `{% partialdef form inline %}` block containing the form markup. The `inline` keyword renders the block in place on a full-page load; on an HTMX submit `render_partial_response` returns only the `form` partial.
 
 ### `render_paginated_response` - paginated list with no COUNT query
 

--- a/template/docs/Validation.md
+++ b/template/docs/Validation.md
@@ -41,8 +41,9 @@ def edit_item(
     )
 ```
 
-The template defines a `{% partialdef form %}` block containing the form markup. On
-an HTMX POST with a validation error, `render_partial_response` returns only that
+The template defines a `{% partialdef form inline %}` block containing the form
+markup. The `inline` keyword renders the block in place on a full-page load; on an
+HTMX POST with a validation error, `render_partial_response` returns only that
 partial so the form re-renders in place with error messages. On success, redirect
 (Post/Redirect/Get) as normal.
 


### PR DESCRIPTION
Without `inline`, `{% partialdef %}` defines a named fragment but does not render it in place — the block is invisible on a full-page load. Page-level templates (forms, paginated lists) must use `{% partialdef name inline %}` so the content renders on full-page loads AND remains extractable by `render_partial_response` for HTMX swaps.

Update Django-Templates.md to explain the distinction and update the example. Update HTMX.md and Validation.md to use the correct syntax.