### PR TITLE
feat: add try_include tag, rename form/fields.html, remove alias partials

### DIFF
--- a/template/.agents/skills/djstudio/commands/a11y.md
+++ b/template/.agents/skills/djstudio/commands/a11y.md
@@ -20,7 +20,7 @@ risks breaking the `<label>`–`<input>` association and `aria-describedby` on e
 |---|---|
 | `{% render_field %}` without a label wrapper | VIOLATION |
 | `{{ form.as_div }}` | WARNING — bypasses configured renderer |
-| `{% include "form/fields.html" %}` | VIOLATION — the include path is wrong; use `as_field_group` |
+| `{% include "form/partials.html" %}` | VIOLATION — the include path is wrong; use `as_field_group` |
 | Radio/checkbox group using `<label>` instead of `<fieldset>`+`<legend>` | WARNING |
 
 ---

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -72,7 +72,7 @@ Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`
 2. `{% for field in form %} {{ field.as_field_group }} {% endfor %}` — all fields, default order
 3. `{{ form }}` — all fields via configured renderer
 
-Never use `{{ form.as_div }}` or `{% include "form/fields.html" %}`.{% endraw %}
+Never use `{{ form.as_div }}` or `{% include "form/partials.html" %}`.{% endraw %}
 See `docs/Django-Templates.md`.
 
 **Internationalisation**: All user-visible text must be wrapped in translation functions. See `docs/Django.md` for usage.

--- a/template/docs/Design.md
+++ b/template/docs/Design.md
@@ -35,7 +35,7 @@ opacity-50" aria_hidden="true" %}
 
 ## Forms
 
-Form rendering uses `{{ field.as_field_group }}` (dispatches through `templates/form/fields.html`
+Form rendering uses `{{ field.as_field_group }}` (dispatches through `templates/form/partials.html`
 to widget-specific `{% partialdef %}` blocks), `django-widget-tweaks` for per-field attribute
 overrides, and `{% fragment "form.html" %}` as the HTMX-aware `<form>` wrapper.
 

--- a/template/docs/Django-Templates.md
+++ b/template/docs/Django-Templates.md
@@ -56,9 +56,22 @@ On an HTMX request targeting `#item-list`, `render_partial_response` returns onl
 
 Component templates such as `browse.html`, `paginate.html`, and `sidebar.html` define partials without `inline` because they are always rendered via `{% fragment %}` or `{% partial %}` — never directly. The caller controls what gets rendered.
 
+### Extracting shared partials into partials.html
+
+When several templates share the same `{% partialdef %}` blocks (e.g. a card layout, a status badge, a shared action menu), extract them into a dedicated `partials.html` file. Callers include the partial via `{% fragment "partials.html#block-name" %}`.
+
+Conventional locations:
+
+| Scope | File |
+|-------|------|
+| Project-wide | `templates/partials.html` |
+| Domain-specific | `templates/form/partials.html`, `templates/my_app/partials.html` |
+
+`form/partials.html` follows this pattern — it holds all form-field widget partials and is included indirectly by Django's field renderer.
+
 ## fragment Tag
 
-`{% fragment "template.html#partial" %}...{% endfragment %}` includes a template and passes the enclosed content as `{{ content }}`. Used internally by `form/fields.html` and `paginate.html`:
+`{% fragment "template.html#partial" %}...{% endfragment %}` includes a template and passes the enclosed content as `{{ content }}`. Used internally by `form/partials.html` and `paginate.html`:
 
 ```html
 {% fragment "form.html" htmx=True target="my-form" %}
@@ -70,7 +83,7 @@ Component templates such as `browse.html`, `paginate.html`, and `sidebar.html` d
 
 ### Rendering fields
 
-Use `{{ field.as_field_group }}` to render a form field with its label, errors, and help text. The project ships `templates/form/fields.html` which dispatches to a per-widget `partialdef` based on the field's widget type:
+Use `{{ field.as_field_group }}` to render a form field with its label, errors, and help text. The project ships `templates/form/partials.html` which dispatches to a per-widget `partialdef` based on the field's widget type:
 
 ```html
 {% for field in form %}
@@ -112,7 +125,7 @@ Key variables:
 
 ### Field template structure
 
-`form/fields.html` renders each field inside a DaisyUI `fieldset`:
+`form/partials.html` renders each field inside a DaisyUI `fieldset`:
 
 ```html
 <fieldset class="fieldset">
@@ -125,7 +138,7 @@ Key variables:
 
 ### Widget type dispatch
 
-`form/fields.html` dispatches to a `{% partialdef %}` block by lowercasing the widget's class name via `{% try_include "form/fields.html#"|add:widget_type "form/fields.html#input" %}`. If no matching partial exists, it falls back to the `input` partial. Built-in widgets with explicit partials:
+`form/partials.html` dispatches to a `{% partialdef %}` block by lowercasing the widget's class name via `{% try_include "form/partials.html#"|add:widget_type "form/partials.html#input" %}`. If no matching partial exists, it falls back to the `input` partial. Built-in widgets with explicit partials:
 
 | Widget | Partial | DaisyUI class |
 |--------|---------|---------------|
@@ -142,7 +155,7 @@ All other widgets (e.g. `TextInput`, `EmailInput`, `FileInput`, `URLInput`) fall
 
 ### Custom widget partials
 
-If you add a custom widget with non-default rendering, add a matching `{% partialdef %}` block to `templates/form/fields.html`. The partial name is the widget's class name, lowercased. Use `{% partial label %}`, `{% partial errors %}`, and `{% partial help_text %}` to keep rendering consistent. Widgets that render identically to a plain `<input>` need no partial — the fallback handles them.
+If you add a custom widget with non-default rendering, add a matching `{% partialdef %}` block to `templates/form/partials.html`. The partial name is the widget's class name, lowercased. Use `{% partial label %}`, `{% partial errors %}`, and `{% partial help_text %}` to keep rendering consistent. Widgets that render identically to a plain `<input>` need no partial — the fallback handles them.
 
 ### Adding widget attributes
 
@@ -310,7 +323,7 @@ Always append to an existing file — never recreate it. App-level files need a
 | `{% active_app 'name' %}` | `simple_tag` | CSS class when `request.resolver_match.app_name` matches |
 | `{% active_url 'name' %}` | `simple_tag` | CSS class when `request.resolver_match.url_name` matches |
 | `{% fragment "t.html" %}...{% endfragment %}` | `simple_block_tag` | Include a template with `{{ content }}` slot |
-| `{% try_include "t.html" "fallback.html" %}` | `simple_tag` | Include a template, falling back if not found |
+| `{% try_include "t.html" "fallback.html" key=val %}` | `simple_tag` | Include a template, falling back if not found; optional extra context |
 | `{% cookie_banner %}` | `inclusion_tag` | GDPR cookie consent banner |
 | `{% title_tag %}` | `simple_tag` | Composable `<title>` tag |
 

--- a/template/docs/Packages.md
+++ b/template/docs/Packages.md
@@ -66,7 +66,7 @@ State your findings explicitly when suggesting a package — don't just name it.
 - **django-money**: pairs with `py-moneyed`. Use `MoneyField` on models;
   arithmetic respects currency. `MoneyWidget` renders an amount input and a
   currency select side-by-side; add a `{% partialdef moneywidget %}` block to
-  `templates/form/fields.html` to style it:
+  `templates/form/partials.html` to style it:
 
   ```html
   {# django-money MoneyWidget (amount + currency select) #}

--- a/template/docs/Validation.md
+++ b/template/docs/Validation.md
@@ -55,7 +55,7 @@ Key rules:
   so HTMX swaps the re-rendered form with inline error messages.
 
 **Form rendering** — use `{{ field.as_field_group }}` for fields (renders via
-`templates/form/fields.html` with widget dispatch and DaisyUI classes), `django-widget-tweaks`
+`templates/form/partials.html` with widget dispatch and DaisyUI classes), `django-widget-tweaks`
 `render_field` to override individual field attributes, and `{% fragment "form.html" %}` as the
 HTMX-aware form wrapper. See `docs/Django-Templates.md` for the full reference.
 

--- a/template/templates/django/forms/field.html
+++ b/template/templates/django/forms/field.html
@@ -1,1 +1,1 @@
-{% include "form/fields.html" %}
+{% include "form/partials.html" %}

--- a/template/templates/form/partials.html
+++ b/template/templates/form/partials.html
@@ -1,8 +1,8 @@
 {% load heroicons i18n widget_tweaks %}
 
-{% fragment "form/fields.html#fieldset" %}
+{% fragment "form/partials.html#fieldset" %}
   {% with widget_type=field|widget_type %}
-    {% try_include "form/fields.html#"|add:widget_type "form/fields.html#input" %}
+    {% try_include "form/partials.html#"|add:widget_type "form/partials.html#input" %}
   {% endwith %}
 {% endfragment %}
 

--- a/template/{{ package_name }}/templatetags.py.jinja
+++ b/template/{{ package_name }}/templatetags.py.jinja
@@ -170,14 +170,18 @@ def fragment(
 
 
 @register.simple_tag(takes_context=True)
-def try_include(context: "Context", template_name: str, fallback: str) -> str:
+def try_include(
+    context: "Context", template_name: str, fallback: str, **extra_context
+) -> str:
     """Include a template, falling back to ``fallback`` if not found.
 
     Useful for optional per-widget overrides where a sensible default exists.
+    Extra keyword arguments are pushed onto the context for the render.
 
     Example:
 
-        {% raw %}{% try_include "form/fields.html#"|add:widget_type "form/fields.html#input" %}{% endraw %}
+        {% raw %}{% try_include "form/partials.html#"|add:widget_type "form/partials.html#input" %}{% endraw %}
+        {% raw %}{% try_include "tmpl_a.html" "tmpl_b.html" foo=bar %}{% endraw %}
     """
     if context.template is None:
         raise template.TemplateSyntaxError(
@@ -189,4 +193,5 @@ def try_include(context: "Context", template_name: str, fallback: str) -> str:
         tmpl = engine.get_template(template_name)
     except TemplateDoesNotExist:
         tmpl = engine.get_template(fallback)
-    return tmpl.render(context)
+    with context.push(**extra_context):
+        return tmpl.render(context)

--- a/template/{{ package_name }}/tests/test_templatetags.py.jinja
+++ b/template/{{ package_name }}/tests/test_templatetags.py.jinja
@@ -142,7 +142,7 @@ class TestTryInclude:
             try_include(context, "primary.html", "fallback.html")
 
     def test_renders_primary_when_found(self, mocker):
-        context = mocker.Mock()
+        context = mocker.MagicMock()
         tmpl = mocker.Mock()
         tmpl.render.return_value = "primary content"
         context.template.engine.get_template.return_value = tmpl
@@ -151,7 +151,7 @@ class TestTryInclude:
         assert result == "primary content"
 
     def test_falls_back_when_primary_not_found(self, mocker):
-        context = mocker.Mock()
+        context = mocker.MagicMock()
         fallback_tmpl = mocker.Mock()
         fallback_tmpl.render.return_value = "fallback content"
         context.template.engine.get_template.side_effect = [
@@ -160,3 +160,11 @@ class TestTryInclude:
         ]
         result = try_include(context, "primary.html", "fallback.html")
         assert result == "fallback content"
+
+    def test_extra_context_pushed(self, mocker):
+        context = mocker.MagicMock()
+        tmpl = mocker.Mock()
+        tmpl.render.return_value = "content"
+        context.template.engine.get_template.return_value = tmpl
+        try_include(context, "primary.html", "fallback.html", foo="bar")
+        context.push.assert_called_once_with(foo="bar")


### PR DESCRIPTION
## Summary

- Adds `{% try_include template fallback %}` builtin tag — renders the named template/partial, falls back to `fallback` on `TemplateDoesNotExist`. Fixes crashes when a widget has no explicit partial in `form/fields.html`.
- Replaces `{% include %}` in `form/fields.html` with `{% try_include ... "form/fields.html#input" %}` so unknown widgets automatically fall back to the `input` partial.
- Removes the five pass-through alias partials (`textinput`, `emailinput`, `fileinput`, `clearablefileinput`, `urlinput`) — the fallback now handles them.
- Renames `form/field.html` → `form/fields.html`.
- Removes the `moneywidget` partial from `form/fields.html`; moves the snippet to `docs/Packages.md` under the django-money entry.
- Adds tests for `try_include`: no-context error, primary found, fallback on missing template.