### PR TITLE
fix: populate existing rows in search trigger migration

### DIFF
--- a/template/docs/Django-Models.md
+++ b/template/docs/Django-Models.md
@@ -132,7 +132,7 @@ CREATE TRIGGER my_app_update_search_trigger
 BEFORE INSERT OR UPDATE OF title, description ON my_app_item
 FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger(
     search_vector, 'pg_catalog.simple', title, description);
-UPDATE my_app_item SET search_vector = NULL;""",
+UPDATE my_app_item SET title = title;""",
             reverse_sql=(
                 "DROP TRIGGER IF EXISTS my_app_update_search_trigger ON my_app_item;"
             ),


### PR DESCRIPTION
## Summary

- Replace `SET search_vector = NULL` with `SET title = title` in the migration template
- `SET search_vector = NULL` does not fire the trigger (which only fires on `UPDATE OF title, description`), leaving existing rows with `search_vector = NULL` and breaking full-text search
- `SET title = title` touches the `title` column, fires the `BEFORE UPDATE` trigger, and correctly populates `search_vector` for all existing rows

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)