### PR TITLE
fix(templatetags): Allow re_active_url to accept URL args and kwargs

### DIFF
--- a/template/{{ package_name }}/templatetags.py.jinja
+++ b/template/{{ package_name }}/templatetags.py.jinja
@@ -2,7 +2,7 @@ import functools
 import json
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from django import template
 from django.conf import settings
@@ -110,10 +110,10 @@ class ActiveUrl:
 def active_url(
     context: "RequestContext",
     viewname: str,
-    *args: object,
+    *args: Any,
     active_class: str = "",
     inactive_class: str = "",
-    **url_kwargs: object,
+    **url_kwargs: Any,
 ) -> ActiveUrl:
     """Resolve a URL and return an ActiveUrl indicating whether it is current.
 
@@ -125,10 +125,7 @@ def active_url(
         {% raw %}{% active_url 'account_email' active_class=active_class as match %}{% endraw %}
         {% raw %}{% active_url 'post_detail' post.pk active_class=active_class as match %}{% endraw %}
     """
-    try:
-        url = reverse(viewname, args=args, kwargs=url_kwargs)
-    except NoReverseMatch:
-        url = ""
+    url = _resolve_url(viewname, args, url_kwargs)
     is_active = bool(url) and context.request.path == url
     return ActiveUrl(url=url, is_active=is_active, active_class=active_class, inactive_class=inactive_class)
 
@@ -138,23 +135,23 @@ def re_active_url(
     context: "RequestContext",
     pattern: str,
     viewname: str = "",
-    *,
+    *args: Any,
     active_class: str = "",
     inactive_class: str = "",
+    **url_kwargs: Any,
 ) -> ActiveUrl:
     """Match current path against a pattern and return an ActiveUrl.
 
     Use when a nav item should be active across multiple URL patterns. Pass
-    a viewname as the second argument to resolve the href URL.
+    a viewname as the second argument to resolve the href URL. Accepts the
+    same positional and keyword arguments as the ``url`` tag.
 
     Example:
         {% raw %}{% re_active_url 'password/(change|set)' 'account_change_password' active_class=active_class as pw %}{% endraw %}
+        {% raw %}{% re_active_url 'posts/\\d+' 'post_detail' post.pk active_class=active_class as pw %}{% endraw %}
         {% raw %}<a href="{{ pw.url }}" class="{{ pw.css_class }}">Password</a>{% endraw %}
     """
-    try:
-        url = reverse(viewname) if viewname else ""
-    except NoReverseMatch:
-        url = viewname
+    url = _resolve_url(viewname, args, url_kwargs)
     is_active = bool(re.search(pattern, context.request.path))
     return ActiveUrl(url=url, is_active=is_active, active_class=active_class, inactive_class=inactive_class)
 
@@ -221,3 +218,13 @@ def try_include(
         tmpl = engine.get_template(fallback)
     with context.push(**extra_context):
         return tmpl.render(context)
+
+
+def _resolve_url(viewname: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> str:
+    """Resolve a URL by viewname, returning empty string on failure."""
+    if not viewname:
+        return ""
+    try:
+        return reverse(viewname, args=args, kwargs=kwargs)
+    except NoReverseMatch:
+        return ""

--- a/template/{{ package_name }}/tests/test_templatetags.py.jinja
+++ b/template/{{ package_name }}/tests/test_templatetags.py.jinja
@@ -151,6 +151,30 @@ class TestReActiveUrl:
         result = re_active_url(ctx, "password/(change|set)", "account_change_password")
         assert result.url == "/account/password/change/"
 
+    def test_resolves_viewname_with_url_args(self, rf, mocker):
+        mocker.patch(
+            "{{ package_name }}.templatetags.reverse",
+            return_value="/posts/42/",
+        )
+        req = rf.get("/posts/42/")
+        ctx = Mock()
+        ctx.request = req
+        result = re_active_url(ctx, r"posts/\d+", "post_detail", 42)
+        assert result.url == "/posts/42/"
+        assert result.is_active is True
+
+    def test_resolves_viewname_with_url_kwargs(self, rf, mocker):
+        mocker.patch(
+            "{{ package_name }}.templatetags.reverse",
+            return_value="/posts/42/",
+        )
+        req = rf.get("/posts/42/")
+        ctx = Mock()
+        ctx.request = req
+        result = re_active_url(ctx, r"posts/\d+", "post_detail", pk=42)
+        assert result.url == "/posts/42/"
+        assert result.is_active is True
+
 
 class TestFragment:
     def test_raises_when_no_template_in_context(self, mocker):


### PR DESCRIPTION
`re_active_url` used a keyword-only barrier (`*`) after `viewname`, making it
impossible to pass positional or keyword URL arguments to `reverse()`. Any nav
item pointing to a view with URL parameters (e.g. a detail view) had to fall
back to `active_url`, losing the regex-based active state matching.

Adds `*args` and `**url_kwargs` to `re_active_url`, matching the existing
signature of `active_url`. Extracts the shared `reverse`/`NoReverseMatch`
boilerplate into a private `_resolve_url` helper used by both tags.