### PR TITLE
feat: add MCP server support to generated projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ memory/
 
 # Claude Code (personal settings — not for version control)
 /.claude/
+/.mcp.json
 
 # Testing
 .pytest_cache/

--- a/README.md
+++ b/README.md
@@ -158,6 +158,19 @@ Generated projects include a `/djstudio` Claude Code slash command with subcomma
 | `rotate-secrets`       | Rotate auto-generated and third-party Helm secrets and redeploy                |
 | `enable-db-backups`    | Enable automated daily PostgreSQL backups to a private Object Storage bucket   |
 
+## MCP Servers
+
+Generated projects include project-local [MCP servers](https://modelcontextprotocol.io) configured in `.mcp.json` (gitignored, generated at project creation). These give AI assistants direct access to your local development environment.
+
+| Server | Purpose |
+| ------ | ------- |
+| `@modelcontextprotocol/server-postgres` | Direct database queries and schema inspection |
+| `@playwright/mcp` | Browser automation and E2E test debugging |
+| `mcp-django` | Django shell — ORM queries, model introspection, arbitrary Python |
+| `mcp-server-kubernetes` | Cluster management and log access (added post-launch by `/djstudio launch`) |
+
+See `docs/MCP.md` in the generated project for usage and security notes.
+
 ## Hosting
 
 [Hetzner Cloud](https://hetzner.com) is a very cost-effective, EU-based hosting provider. Cloudflare is currently the cheapest and most secure option for DNS, CDN, SSL, and DDoS protection. These solutions will be reviewed on a regular basis - if better options become available, they will be offered instead of or addition to these choices.

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -157,6 +157,37 @@ def install_claude_hooks() -> None:
     (commands_dst / "djstudio.md").write_text("@.agents/skills/djstudio/SKILL.md\n")
 
 
+# ── MCP config ───────────────────────────────────────────────────────────────
+
+
+def install_mcp_config() -> None:
+    """Write .mcp.json with project-local MCP servers (gitignored)."""
+    config = {
+        "mcpServers": {
+            "postgres": {
+                "command": "sh",
+                "args": [
+                    "-c",
+                    "set -a; . ./.env; set +a;"
+                    ' npx -y @modelcontextprotocol/server-postgres "$DATABASE_URL"',
+                ],
+            },
+            "playwright": {
+                "command": "npx",
+                "args": ["@playwright/mcp"],
+            },
+            "django": {
+                "command": "uv",
+                "args": ["run", "python", "-m", "mcp_django"],
+                "env": {"DJANGO_SETTINGS_MODULE": "config.settings"},
+            },
+        }
+    }
+    with (BASE_DIR / ".mcp.json").open("w") as f:
+        json.dump(config, f, indent=2)
+        f.write("\n")
+
+
 # ── main ─────────────────────────────────────────────────────────────────────
 
 # 1. Install license file
@@ -168,8 +199,9 @@ for path in PLAIN_SLUG_FILES:
     if path.exists():
         path.write_text(path.read_text().replace("PROJECT_SLUG", PROJECT_SLUG))
 
-# 4. Install Claude hooks and generate lock file
+# 4. Install Claude hooks, MCP config, and generate lock file
 install_claude_hooks()
+install_mcp_config()
 
 # Generate uv.lock so CI's `uv sync --frozen` works without a manual step
 subprocess.run(["uv", "lock"], check=True)

--- a/template/.agents/skills/djstudio/commands/launch.md
+++ b/template/.agents/skills/djstudio/commands/launch.md
@@ -583,6 +583,41 @@ Diagnose and help the user fix the issue before declaring success.
 
 ---
 
+## Step 6d — Kubernetes MCP
+
+Now that the cluster is live, offer to add the Kubernetes MCP server to `.mcp.json`
+so AI assistants can inspect pods, logs, and deployments directly.
+
+Tell the user:
+
+> Would you like to add the Kubernetes MCP server to `.mcp.json`?
+> This lets AI assistants (Claude Code) inspect pods, view logs, and manage
+> deployments using your current kubectl context.
+>
+> Add Kubernetes MCP? (y/n)
+
+If **y**, patch `.mcp.json`:
+
+```bash
+python3 -c "
+import json, pathlib
+p = pathlib.Path('.mcp.json')
+config = json.loads(p.read_text())
+config['mcpServers']['kubernetes'] = {
+    'command': 'npx',
+    'args': ['-y', 'mcp-server-kubernetes']
+}
+p.write_text(json.dumps(config, indent=2) + '\n')
+"
+```
+
+Tell the user:
+> Kubernetes MCP added to `.mcp.json`. Restart Claude Code to activate it.
+
+If **n**, skip silently.
+
+---
+
 ## Step 7 — Observability
 
 Check whether `helm/observability/values.secret.yaml` exists.
@@ -603,8 +638,9 @@ configuring secrets, and deploying the application end-to-end.
 
 Covers: Hetzner infrastructure (Terraform), Cloudflare DNS and SSL, object
 storage (if enabled), Helm secrets, GitHub Actions secrets, the three-step
-first production deploy (build image → deploy infra → deploy app), and
-configuring the default Django site (`set_default_site`). Idempotent —
+first production deploy (build image → deploy infra → deploy app),
+configuring the default Django site (`set_default_site`), and optionally
+adding the Kubernetes MCP server to `.mcp.json`. Idempotent —
 safe to re-run if interrupted; existing values are never overwritten.
 
 Requires: `gh`, `terraform`, `helm`, `kubectl`, and `just` installed and

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -119,6 +119,7 @@ actively, not as background reading.
 | Sending email (transactional / dev) | `docs/Sending-Emails.md` |
 | Testing patterns                | `docs/Testing.md` |
 | Any of the above                | `docs/Project-Structure.md` |
+| MCP servers (postgres, django shell, Playwright, k8s) | `docs/MCP.md` |
 
 If a doc contradicts what you see in existing code, flag it — do not silently pick one.
 
@@ -186,6 +187,21 @@ Invoke with `/djstudio <subcommand>` in Claude Code.
 | `rotate-secrets` | Rotate auto-generated and third-party Helm secrets and redeploy |
 | `enable-db-backups` | Enable automated daily PostgreSQL backups to Object Storage |
 
+
+## MCP Servers
+
+The following MCP servers are configured in `.mcp.json` (gitignored, generated at project creation). They are available to Claude Code when the project is open.
+
+| Server | When available | Capability |
+| ------ | -------------- | ---------- |
+| `postgres` | Always | Execute SQL, inspect schema, check migrations |
+| `playwright` | Always | Browser automation, E2E test debugging |
+| `django` | Always | Django shell: ORM queries, model introspection, arbitrary Python in Django context |
+| `kubernetes` | After `/djstudio launch` | Inspect pods, view logs, manage deployments |
+
+Use `postgres` and `django` to debug data issues. Use `playwright` to investigate E2E failures interactively. Use `kubernetes` to diagnose production pod failures without leaving the editor.
+
+See `docs/MCP.md` for details.
 
 ## Template Feedback
 

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -103,6 +103,21 @@ Claude Code slash commands are available via `/djstudio <subcommand>`:
 | `rotate-secrets`       | Rotate auto-generated and third-party Helm secrets and redeploy                |
 | `enable-db-backups`    | Enable automated daily PostgreSQL backups to a private Object Storage bucket   |
 
+## MCP Servers
+
+Project-local [MCP servers](https://modelcontextprotocol.io) are configured in `.mcp.json` (gitignored, generated at project creation). Restart Claude Code after project setup to activate them.
+
+| Server | Purpose |
+| ------ | ------- |
+| `@modelcontextprotocol/server-postgres` | Direct database queries and schema inspection |
+| `@playwright/mcp` | Browser automation and E2E test debugging |
+| `mcp-django` | Django shell — ORM queries, model introspection, arbitrary Python |
+| `mcp-server-kubernetes` | Cluster management and log access (added by `/djstudio launch`) |
+
+> **Security:** `mcp-django` gives full shell access to your Django project. Use in development only; never point it at a database containing production data.
+
+See `docs/MCP.md` for details and usage examples.
+
 ## Stack
 
 - Python 3.14, Django 6.0, PostgreSQL 18, Redis 8

--- a/template/docs/MCP.md
+++ b/template/docs/MCP.md
@@ -1,0 +1,101 @@
+# MCP Servers
+
+This project ships with project-local [Model Context Protocol](https://modelcontextprotocol.io)
+(MCP) servers configured in `.mcp.json`. MCP servers give AI assistants (Claude Code) direct
+access to your local environment — databases, browsers, the Django shell, and (post-launch)
+your Kubernetes cluster.
+
+`.mcp.json` is gitignored and generated at project creation by the Copier post-gen hook.
+Restart Claude Code after running `just install` to activate the servers.
+
+---
+
+## Servers
+
+### PostgreSQL
+
+**Package:** `@modelcontextprotocol/server-postgres`
+
+Connects to the local development database using `DATABASE_URL` from `.env`. Requires
+Docker services to be running (`just start`).
+
+**Use for:**
+- Inspecting table schema and indexes
+- Running ad-hoc SQL queries during debugging
+- Verifying migration output
+- Checking data state without opening a `psql` shell
+
+### Playwright
+
+**Package:** `@playwright/mcp`
+
+Launches a browser that Claude Code can control directly.
+
+**Use for:**
+- Investigating E2E test failures interactively
+- Capturing screenshots of UI bugs
+- Reproducing flaky test sequences step-by-step
+
+### Django shell
+
+**Package:** `mcp-django` (`uv run python -m mcp_django`)
+
+Starts a Django shell session with the full application context loaded
+(`DJANGO_SETTINGS_MODULE=config.settings`).
+
+**Use for:**
+- ORM queries and queryset debugging
+- Model introspection (`MyModel._meta.get_fields()`)
+- Calling service functions and management utilities directly
+- Checking signal wiring and middleware state
+
+> **Security warning:** This server gives full Python shell access to your Django project,
+> including the database. Use it in development only. Never run it against a database that
+> contains production data.
+
+### Kubernetes
+
+**Package:** `mcp-server-kubernetes`
+
+Uses your current `kubectl` context (configured by `just get-kubeconfig` during
+`/djstudio launch`). Added to `.mcp.json` at the end of the launch wizard — not present
+in fresh projects.
+
+**Use for:**
+- Checking pod status and events: `kubectl get pods`
+- Reading application logs: `kubectl logs <pod>`
+- Describing failing deployments
+- Inspecting ConfigMaps and Secrets (non-sensitive values)
+
+To add it manually after launch:
+
+```bash
+python3 -c "
+import json, pathlib
+p = pathlib.Path('.mcp.json')
+config = json.loads(p.read_text())
+config['mcpServers']['kubernetes'] = {
+    'command': 'npx',
+    'args': ['-y', 'mcp-server-kubernetes']
+}
+p.write_text(json.dumps(config, indent=2) + '\n')
+"
+```
+
+---
+
+## Troubleshooting
+
+**Servers not appearing in Claude Code**
+Restart Claude Code after project setup. MCP servers are loaded at startup.
+
+**`postgres` fails to connect**
+Run `just start` to ensure Docker services are running, then verify `DATABASE_URL` in `.env`.
+
+**`django` fails to start**
+Run `just install` to ensure `mcp-django` is installed in the project virtualenv.
+Check that `config/settings.py` loads without errors: `uv run python -m django check`.
+
+**`kubernetes` context is wrong**
+Run `just get-kubeconfig` to refresh the kubeconfig from the Hetzner cluster, then
+restart Claude Code.

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -69,6 +69,7 @@ dev = [
   "pytest>=8.3.2",
   "ruff>=0.15.2",
   "djlint>=1.36.4",
+  "mcp-django>=0.13.0",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Generated projects now include a `.mcp.json` (gitignored, written by the post-gen hook alongside `.claude/settings.json`) with three project-local MCP servers:

- postgres: reads DATABASE_URL from .env, connects via @modelcontextprotocol/server-postgres
- playwright: browser automation via @playwright/mcp
- django: Django shell access via mcp-django (ORM queries, model introspection)

The Kubernetes MCP (mcp-server-kubernetes) is added post-launch: the /djstudio launch skill now offers to patch .mcp.json after pods are confirmed running.

Also adds docs/MCP.md with server reference, security notes, and troubleshooting; updates README.md, template/README.md.jinja, and AGENTS.md.jinja with MCP sections.