### PR TITLE
fix(paginator): restore ObjectList alias to support QuerySet alongside Sequence

### DIFF
--- a/template/{{ package_name }}/paginator.py.jinja
+++ b/template/{{ package_name }}/paginator.py.jinja
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, runtime_checkable
 
 from django.conf import settings
 from django.core.paginator import EmptyPage, PageNotAnInteger
@@ -12,9 +12,12 @@ from {{ package_name }}.partials import render_partial_response
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from django.db.models import QuerySet
     from django.template.response import TemplateResponse
 
     from {{ package_name }}.http.request import HttpRequest
+
+    ObjectList: TypeAlias = Sequence | QuerySet
 
 
 @runtime_checkable
@@ -135,7 +138,7 @@ class ZeroCountPage:
 class ZeroCountPaginator:
     """Paginator that avoids COUNT(*) queries."""
 
-    def __init__(self, object_list: Sequence, per_page: int) -> None:
+    def __init__(self, object_list: ObjectList, per_page: int) -> None:
         self.object_list = object_list
         self.per_page = per_page
 
@@ -152,7 +155,7 @@ class ZeroCountPaginator:
 def render_paginated_response(
     request: HttpRequest,
     template_name: str,
-    object_list: Sequence,
+    object_list: ObjectList,
     extra_context: dict | None = None,
     config: PaginationConfig | None = None,
 ) -> TemplateResponse:

--- a/template/{{ package_name }}/tests/test_paginator.py.jinja
+++ b/template/{{ package_name }}/tests/test_paginator.py.jinja
@@ -208,6 +208,14 @@ class TestRenderPaginatedResponse:
         response = render_paginated_response(request, "template.html", [], config=config)
         assert response.context_data["paginator"].per_page == 2
 
+    def test_queryset_compatible(self, rf):
+        """QuerySet must be accepted — QuerySet doesn't inherit Sequence in django-stubs."""
+        from {{ package_name }}.users.models import User
+
+        request = self._make_request(rf)
+        response = render_paginated_response(request, "template.html", User.objects.none())
+        assert response.context_data["page"].number == 1
+
     def test_custom_page_param(self, rf):
         request = rf.get("/", {"p": "2"})
         request.htmx = HtmxDetails(request)


### PR DESCRIPTION
Fixes #209

`QuerySet` does not inherit `collections.abc.Sequence` in django-stubs — it is missing `index()`. Annotating `object_list` as `Sequence` alone rejects `QuerySet` arguments at the type-checker level, breaking any view that passes `MyModel.objects.all()` to `render_paginated_response`.

## Changes

- Restore `ObjectList: TypeAlias = Sequence | QuerySet` in the `TYPE_CHECKING` block of `paginator.py`
- Use `ObjectList` in `ZeroCountPaginator.__init__` and `render_paginated_response` parameter signatures
- Add `test_queryset_compatible` — passes `User.objects.none()` (no DB query) to `render_paginated_response` to catch this regression in the template test suite