### PR TITLE
refactor(paginator): simplify paginator module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,23 @@ Command files live in `template/.agents/` and are copied verbatim by Copier into
 
 Create the file under `template/.agents/skills/djstudio/commands/<subcommand>.md`. No `copier.yml` change is needed — Copier copies the entire `template/.agents/` tree verbatim.
 
+## Python 3.14 — `except` Without Parentheses (PEP 758)
+
+`pyupgrade --py314` rewrites multi-exception handlers to the Python 3.14 syntax:
+
+```python
+# Before (pyupgrade rewrites this automatically)
+except (ValueError, TypeError):
+
+# After — correct Python 3.14 syntax (PEP 758)
+except ValueError, TypeError:
+```
+
+**Do not revert this.** AI assistants commonly flag it as invalid syntax and revert
+it to the parenthesised form — that is wrong. The parenthesised form is the
+pre-3.14 style; the unparenthesised form is now correct.
+See [pyright#10546](https://github.com/microsoft/pyright/issues/10546) for upstream tracking.
+
 ## Bugs and Improvements
 
 Use the `/djstudio feedback` skill to report bugs or suggest improvements to this template - it posts a GitHub issue directly. Requires the `gh` CLI authenticated with GitHub access.

--- a/template/docs/Pagination.md
+++ b/template/docs/Pagination.md
@@ -1,8 +1,7 @@
 # Pagination
 
-This project ships a custom `ZeroCountPaginator` that avoids `COUNT(*)` queries by fetching one
-extra row to detect whether a next page exists. Choose the right approach for your use
-case:
+Use `render_paginated_response` for all paginated views. Choose the right approach for
+your use case:
 
 | Use case | Approach |
 |---|---|
@@ -10,6 +9,7 @@ case:
 | User needs to jump to a specific page | Numbered pages |
 | Feed-style content | Infinite scroll |
 | Django admin on large tables | `FastCountAdminMixin` |
+| Large tables where COUNT(*) is too slow | [Performance Optimizations](#performance-optimizations) |
 
 ---
 
@@ -18,11 +18,13 @@ case:
 - [Previous/Next (default)](#previousnext-default)
 - [Numbered Pagination](#numbered-pagination)
 - [Infinite Scroll](#infinite-scroll)
+- [Performance Optimizations](#performance-optimizations)
 - [Django Admin: FastCountAdminMixin](#django-admin-fastcountadminmixin)
 
 ## Previous/Next (default)
 
-Use `render_paginated_response`. No `COUNT(*)` query — scales well on large tables.
+Use `render_paginated_response` with no custom paginator — Django's built-in `Paginator`
+is used by default.
 
 ```python
 from my_package.paginator import render_paginated_response
@@ -57,10 +59,13 @@ In the template, include `paginate.html` via `{% fragment %}` inside a
 `paginate.html` renders Previous/Next navigation around `{{ content }}`.
 On an HTMX page request only the `pagination` partial is returned.
 
-To override the page size, pass a `ZeroCountPaginator` instance directly:
+To override the page size, pass a `Paginator` instance directly:
 
 ```python
-from my_package.paginator import ZeroCountPaginator, PaginationConfig, render_paginated_response
+from django.core.paginator import Paginator
+
+from my_package.paginator import PaginationConfig, render_paginated_response
+
 
 def item_list(request: HttpRequest) -> TemplateResponse:
     qs = Item.objects.order_by("-created_at")
@@ -68,7 +73,7 @@ def item_list(request: HttpRequest) -> TemplateResponse:
         request,
         "my_app/items_list.html",
         qs,
-        config=PaginationConfig(paginator=ZeroCountPaginator(qs, 50)),
+        config=PaginationConfig(paginator=Paginator(qs, 50)),
     )
 ```
 
@@ -180,14 +185,169 @@ Use it in the page template the same way as `paginate.html`:
 The ±3 window in `paginate_numbered.html` keeps the page range short on large datasets.
 Adjust `add:"-3"` / `add:"3"` to taste.
 
-### FastCountPaginator (large unfiltered tables)
+For very large unfiltered tables where `COUNT(*)` is slow, see
+[FastCountPaginator](#fastcountpaginator--estimated-counts-for-numbered-pagination).
 
-For tables with millions of rows where `COUNT(*)` is too slow, use
-`FastCountPaginator` instead. It reads PostgreSQL's `pg_class.reltuples` statistic —
-essentially free — for unfiltered querysets, falling back to `COUNT(*)` when filters
-are applied.
+---
 
-Add to `my_package/paginator.py`:
+## Infinite Scroll
+
+Feed-style content that loads automatically as the user scrolls. Uses HTMX's
+`revealed` trigger on a sentinel element at the end of each page.
+
+```python
+from my_package.paginator import PaginationConfig, render_paginated_response
+
+
+def item_list(request: HttpRequest) -> TemplateResponse:
+    return render_paginated_response(
+        request,
+        "my_app/items_list.html",
+        Item.objects.order_by("-created_at"),
+        config=PaginationConfig(target="scroll-sentinel", partial="items"),
+    )
+```
+
+```html
+<!-- my_app/items_list.html -->
+{% extends "base.html" %}
+
+{% block content %}
+  <div id="item-feed">
+    {% partialdef items inline %}
+      {% for item in page.object_list %}
+        <p>{{ item.name }}</p>
+      {% endfor %}
+
+      {% if page.has_next %}
+        <div id="scroll-sentinel"
+             hx-get="{{ request.path }}{% querystring page=page.next_page_number %}"
+             hx-trigger="revealed"
+             hx-swap="outerHTML"
+             aria-hidden="true"></div>
+      {% endif %}
+    {% endpartialdef %}
+  </div>
+{% endblock content %}
+```
+
+On the first load the full page renders. When the sentinel scrolls into view, HTMX
+sends `HX-Target: scroll-sentinel`. `render_paginated_response` matches on `target` and
+returns only the `items` partial — new items plus a fresh sentinel (or nothing on the
+last page). `hx-swap="outerHTML"` replaces the sentinel with the new content, appending
+items in place.
+
+See the [HTMX infinite scroll example](https://htmx.org/examples/infinite-scroll/).
+
+---
+
+## Performance Optimizations
+
+For large tables, add one of these custom paginators to `my_package/paginator.py` and
+pass via `PaginationConfig`.
+
+### ZeroCountPaginator — skip COUNT(*) for previous/next pagination
+
+Avoids `COUNT(*)` entirely by fetching one extra row to detect whether a next page
+exists. Best for large tables used with previous/next or infinite scroll.
+
+```python
+from django.core.paginator import EmptyPage, PageNotAnInteger
+from django.utils.functional import cached_property
+
+
+class ZeroCountPage:
+    """Pagination page without COUNT(*) queries."""
+
+    def __init__(self, *, paginator: "ZeroCountPaginator", number: int) -> None:
+        self.paginator = paginator
+        self.page_size = paginator.per_page
+        self.number = number
+
+    def __len__(self) -> int:
+        return len(self.object_list)
+
+    def __getitem__(self, index):
+        return self.object_list[index]
+
+    def has_next(self) -> bool:
+        return self._has_next
+
+    def has_previous(self) -> bool:
+        return self._has_previous
+
+    def has_other_pages(self) -> bool:
+        return self._has_previous or self._has_next
+
+    def next_page_number(self) -> int:
+        if self._has_next:
+            return self.number + 1
+        raise EmptyPage("Next page does not exist")
+
+    def previous_page_number(self) -> int:
+        if self._has_previous:
+            return self.number - 1
+        raise EmptyPage("Previous page does not exist")
+
+    @cached_property
+    def object_list(self):
+        return self._object_list_with_next_item[: self.page_size]
+
+    @cached_property
+    def _has_next(self) -> bool:
+        return len(self._object_list_with_next_item) > self.page_size
+
+    @cached_property
+    def _has_previous(self) -> bool:
+        return self.number > 1
+
+    @cached_property
+    def _object_list_with_next_item(self) -> list:
+        start = (self.number - 1) * self.page_size
+        end = start + self.page_size + 1
+        return list(self.paginator.object_list[start:end])
+
+
+class ZeroCountPaginator:
+    """Paginator that avoids COUNT(*) queries."""
+
+    def __init__(self, object_list, per_page: int) -> None:
+        self.object_list = object_list
+        self.per_page = per_page
+
+    def get_page(self, number) -> ZeroCountPage:
+        try:
+            number = int(number)
+            if number < 1:
+                raise EmptyPage
+        except TypeError, ValueError:
+            number = 1
+        except EmptyPage:
+            number = 1
+        return ZeroCountPage(paginator=self, number=number)
+```
+
+Use it via `PaginationConfig`:
+
+```python
+from my_package.paginator import PaginationConfig, render_paginated_response
+
+
+def item_list(request: HttpRequest) -> TemplateResponse:
+    qs = Item.objects.order_by("-created_at")
+    return render_paginated_response(
+        request,
+        "my_app/items_list.html",
+        qs,
+        config=PaginationConfig(paginator=ZeroCountPaginator(qs, 50)),
+    )
+```
+
+### FastCountPaginator — estimated counts for numbered pagination
+
+Reads PostgreSQL's `pg_class.reltuples` statistic — essentially free — for unfiltered
+querysets, falling back to `COUNT(*)` when filters are applied. Use with numbered
+pagination on tables with millions of rows.
 
 ```python
 from django.core.paginator import Paginator as DjangoPaginator
@@ -245,65 +405,14 @@ return render_paginated_response(
 
 ---
 
-## Infinite Scroll
-
-Feed-style content that loads automatically as the user scrolls. Uses HTMX's
-`revealed` trigger on a sentinel element at the end of each page.
-
-```python
-from my_package.paginator import PaginationConfig, render_paginated_response
-
-
-def item_list(request: HttpRequest) -> TemplateResponse:
-    return render_paginated_response(
-        request,
-        "my_app/items_list.html",
-        Item.objects.order_by("-created_at"),
-        config=PaginationConfig(target="scroll-sentinel", partial="items"),
-    )
-```
-
-```html
-<!-- my_app/items_list.html -->
-{% extends "base.html" %}
-
-{% block content %}
-  <div id="item-feed">
-    {% partialdef items inline %}
-      {% for item in page.object_list %}
-        <p>{{ item.name }}</p>
-      {% endfor %}
-
-      {% if page.has_next %}
-        <div id="scroll-sentinel"
-             hx-get="{{ request.path }}{% querystring page=page.next_page_number %}"
-             hx-trigger="revealed"
-             hx-swap="outerHTML"
-             aria-hidden="true"></div>
-      {% endif %}
-    {% endpartialdef %}
-  </div>
-{% endblock content %}
-```
-
-On the first load the full page renders. When the sentinel scrolls into view, HTMX
-sends `HX-Target: scroll-sentinel`. `render_paginated_response` matches on `target` and
-returns only the `items` partial — new items plus a fresh sentinel (or nothing on the
-last page). `hx-swap="outerHTML"` replaces the sentinel with the new content, appending
-items in place.
-
-See the [HTMX infinite scroll example](https://htmx.org/examples/infinite-scroll/).
-
----
-
 ## Django Admin: FastCountAdminMixin
 
 Django's admin list view runs `COUNT(*)` on every page load. `FastCountAdminMixin`
 swaps in `FastCountPaginator` and suppresses the second count query used for the
 "X results (Y total)" display.
 
-First add `FastCountPaginator` to `my_package/paginator.py` (see above), then add
-to the app's `admin.py`:
+First add `FastCountPaginator` to `my_package/paginator.py` (see
+[Performance Optimizations](#performance-optimizations)), then add to the app's `admin.py`:
 
 ```python
 from django.contrib import admin

--- a/template/{{ package_name }}/paginator.py.jinja
+++ b/template/{{ package_name }}/paginator.py.jinja
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, runtime_checkable
+from typing import TYPE_CHECKING, TypeAlias
 
 from django.conf import settings
-from django.core.paginator import EmptyPage, PageNotAnInteger
-from django.utils.functional import cached_property
+from django.core.paginator import Paginator
 
 from {{ package_name }}.partials import render_partial_response
 
@@ -20,37 +19,6 @@ if TYPE_CHECKING:
     ObjectList: TypeAlias = Sequence | QuerySet
 
 
-@runtime_checkable
-class Page(Protocol):
-    """Protocol for page objects returned by Paginator.get_page().
-
-    Compatible with both ``django.core.paginator.Page`` and ``ZeroCountPage``.
-    """
-
-    @property
-    def number(self) -> int: ...  # noqa: D102
-
-    @property
-    def object_list(self) -> ObjectList: ...  # noqa: D102
-
-    def has_next(self) -> bool: ...  # noqa: D102
-
-    def has_previous(self) -> bool: ...  # noqa: D102
-
-    def has_other_pages(self) -> bool: ...  # noqa: D102
-
-    def next_page_number(self) -> int: ...  # noqa: D102
-
-    def previous_page_number(self) -> int: ...  # noqa: D102
-
-
-@runtime_checkable
-class Paginator(Protocol):
-    """Protocol for paginator classes compatible with render_paginated_response."""
-
-    def get_page(self, number: int | str) -> Page: ...  # noqa: D102
-
-
 @dataclasses.dataclass(kw_only=True)
 class PaginationConfig:
     """Configuration for render_paginated_response."""
@@ -59,97 +27,6 @@ class PaginationConfig:
     target: str = "pagination"
     partial: str = "pagination"
     paginator: Paginator | None = None
-
-
-class ZeroCountPage:
-    """Pagination page without COUNT(*) queries.
-
-    See: https://testdriven.io/blog/django-avoid-counting/
-
-    Object list access is lazy - no database query runs until the list is
-    iterated or accessed.
-    """
-
-    def __init__(self, *, paginator: ZeroCountPaginator, number: int) -> None:
-        self.paginator = paginator
-        self.page_size = paginator.per_page
-        self.number = number
-
-    def __repr__(self) -> str:
-        """Return object representation."""
-        return f"<ZeroCountPage {self.number}>"
-
-    def __len__(self) -> int:
-        """Return total number of items on this page."""
-        return len(self.object_list)
-
-    def __getitem__(self, index: int | slice) -> Any:
-        """Return item or slice from the object list."""
-        return self.object_list[index]
-
-    def has_next(self) -> bool:
-        """Return True if a next page exists."""
-        return self._has_next
-
-    def has_previous(self) -> bool:
-        """Return True if a previous page exists."""
-        return self._has_previous
-
-    def has_other_pages(self) -> bool:
-        """Return True if any other pages exist."""
-        return self._has_previous or self._has_next
-
-    def next_page_number(self) -> int:
-        """Return the next page number, raising EmptyPage if none exists."""
-        if self._has_next:
-            return self.number + 1
-        raise EmptyPage("Next page does not exist")
-
-    def previous_page_number(self) -> int:
-        """Return the previous page number, raising EmptyPage if none exists."""
-        if self._has_previous:
-            return self.number - 1
-        raise EmptyPage("Previous page does not exist")
-
-    @cached_property
-    def object_list(self) -> ObjectList:
-        """Return the items for this page (without the lookahead item)."""
-        return self._object_list_with_next_item[: self.page_size]
-
-    @cached_property
-    def _has_next(self) -> bool:
-        return len(self._object_list_with_next_item) > self.page_size
-
-    @cached_property
-    def _has_previous(self) -> bool:
-        return self.number > 1
-
-    @cached_property
-    def _object_list_with_next_item(self) -> list:
-        """Return page items plus one extra to determine if a next page exists.
-
-        Fetches ``per_page + 1`` items with LIMIT/OFFSET - no COUNT query.
-        """
-        start = (self.number - 1) * self.page_size
-        end = start + self.page_size + 1
-        return list(self.paginator.object_list[start:end])
-
-
-class ZeroCountPaginator:
-    """Paginator that avoids COUNT(*) queries."""
-
-    def __init__(self, object_list: ObjectList, per_page: int) -> None:
-        self.object_list = object_list
-        self.per_page = per_page
-
-    def get_page(self, number: int | str) -> ZeroCountPage:
-        """Return a ZeroCountPage for the given number, defaulting to page 1 on error."""
-        try:
-            number = validate_page_number(number)
-        except (PageNotAnInteger, EmptyPage):
-            number = 1
-
-        return ZeroCountPage(paginator=self, number=number)
 
 
 def render_paginated_response(
@@ -174,7 +51,7 @@ def render_paginated_response(
     """
     config = config or PaginationConfig()
 
-    paginator = config.paginator or ZeroCountPaginator(object_list, settings.DEFAULT_PAGE_SIZE)
+    paginator = config.paginator or Paginator(object_list, settings.DEFAULT_PAGE_SIZE)
 
     page = paginator.get_page(request.GET.get(config.param, 1))
 
@@ -190,22 +67,3 @@ def render_paginated_response(
         target=config.target,
         partial=config.partial,
     )
-
-
-def validate_page_number(number: int | str) -> int:
-    """Validate and return the page number as a positive integer.
-
-    Args:
-        number: Raw page number (int or string from query params).
-
-    Raises:
-        PageNotAnInteger: If ``number`` cannot be coerced to an integer.
-        EmptyPage: If ``number`` is less than 1.
-    """
-    try:
-        number = int(number)
-    except (TypeError, ValueError) as exc:
-        raise PageNotAnInteger("Page number is not an integer") from exc
-    if number < 1:
-        raise EmptyPage("Page number is less than 1")
-    return number

--- a/template/{{ package_name }}/tests/test_paginator.py.jinja
+++ b/template/{{ package_name }}/tests/test_paginator.py.jinja
@@ -1,132 +1,11 @@
-import pytest
 from django.conf import settings
-from django.core.paginator import EmptyPage, PageNotAnInteger
-from django.core.paginator import Paginator as DjangoPaginator
+from django.core.paginator import Paginator
 from django_htmx.middleware import HtmxDetails
 
 from {{ package_name }}.paginator import (
-    Page,
     PaginationConfig,
-    Paginator,
-    ZeroCountPaginator,
     render_paginated_response,
-    validate_page_number,
 )
-
-
-class TestPageProtocol:
-    def test_zero_count_page_satisfies_protocol(self):
-        assert isinstance(ZeroCountPaginator([1, 2], 10).get_page(1), Page)
-
-    def test_django_page_satisfies_protocol(self):
-        assert isinstance(DjangoPaginator([1, 2], 10).get_page(1), Page)
-
-
-class TestPaginatorProtocol:
-    def test_zero_count_paginator_satisfies_protocol(self):
-        assert isinstance(ZeroCountPaginator([], 10), Paginator)
-
-    def test_django_paginator_satisfies_protocol(self):
-        assert isinstance(DjangoPaginator([], 10), Paginator)
-
-
-class TestPage:
-    def test_is_empty(self):
-        page = ZeroCountPaginator([], 10).get_page(1)
-        assert repr(page) == "<ZeroCountPage 1>"
-        assert len(page) == 0
-        assert page.has_next() is False
-        assert page.has_previous() is False
-        assert page.has_other_pages() is False
-
-    def test_single_page(self):
-        page = ZeroCountPaginator([1, 2], 10).get_page(1)
-        assert len(page) == 2
-        assert page.has_next() is False
-        assert page.has_previous() is False
-        assert page.has_other_pages() is False
-
-    def test_has_next(self):
-        page = ZeroCountPaginator([1, 2, 3], 2).get_page(1)
-        assert page.has_next() is True
-        assert page.has_previous() is False
-        assert page.has_other_pages() is True
-        assert page.next_page_number() == 2
-        with pytest.raises(EmptyPage):
-            _ = page.previous_page_number()
-
-    def test_has_previous(self):
-        page = ZeroCountPaginator([1, 2, 3], 2).get_page(2)
-        assert page.has_previous() is True
-        assert page.has_next() is False
-        assert page.has_other_pages() is True
-        assert page.previous_page_number() == 1
-        with pytest.raises(EmptyPage):
-            _ = page.next_page_number()
-
-    def test_getitem(self):
-        page = ZeroCountPaginator([1, 2, 3], 2).get_page(1)
-        assert page[0] == 1
-
-    def test_repr(self):
-        page = ZeroCountPaginator([1], 10).get_page(1)
-        assert repr(page) == "<ZeroCountPage 1>"
-
-
-class TestZeroCountPaginator:
-    def test_get_page_int(self):
-        page = ZeroCountPaginator([1, 2, 3], 2).get_page(2)
-        assert len(page) == 1
-        assert page.number == 2
-        assert page.has_next() is False
-        assert page.has_previous() is True
-
-    def test_get_page_str(self):
-        page = ZeroCountPaginator([1, 2, 3], 2).get_page("2")
-        assert page.number == 2
-
-    def test_get_page_empty_str_defaults_to_1(self):
-        page = ZeroCountPaginator([1, 2, 3], 2).get_page("")
-        assert page.number == 1
-        assert page.has_next() is True
-
-    def test_get_page_bad_str_defaults_to_1(self):
-        page = ZeroCountPaginator([1, 2, 3], 2).get_page("bad")
-        assert page.number == 1
-
-    def test_get_page_zero_defaults_to_1(self):
-        page = ZeroCountPaginator([1, 2, 3], 2).get_page(0)
-        assert page.number == 1
-
-    def test_get_page_empty_list(self):
-        page = ZeroCountPaginator([], 2).get_page(1)
-        assert len(page) == 0
-        assert page.has_next() is False
-        assert page.has_previous() is False
-
-
-class TestValidatePageNumber:
-    def test_valid_int(self):
-        assert validate_page_number(1) == 1
-
-    def test_valid_str(self):
-        assert validate_page_number("5") == 5
-
-    def test_less_than_1_raises(self):
-        with pytest.raises(EmptyPage):
-            validate_page_number(0)
-
-    def test_negative_raises(self):
-        with pytest.raises(EmptyPage):
-            validate_page_number(-1)
-
-    def test_non_numeric_raises(self):
-        with pytest.raises(PageNotAnInteger):
-            validate_page_number("oops")
-
-    def test_none_raises(self):
-        with pytest.raises(PageNotAnInteger):
-            validate_page_number(None)  # type: ignore[arg-type]
 
 
 class TestPaginationConfig:
@@ -138,7 +17,7 @@ class TestPaginationConfig:
         assert config.paginator is None
 
     def test_custom_values(self):
-        paginator = ZeroCountPaginator([], 10)
+        paginator = Paginator([], 10)
         config = PaginationConfig(
             param="p",
             target="my-list",
@@ -170,7 +49,12 @@ class TestRenderPaginatedResponse:
     def test_page_number_from_query_param(self, rf):
         request = rf.get("/", {"page": "2"})
         request.htmx = HtmxDetails(request)
-        response = render_paginated_response(request, "template.html", [1, 2, 3], config=PaginationConfig(paginator=ZeroCountPaginator([1, 2, 3], 2)))
+        response = render_paginated_response(
+            request,
+            "template.html",
+            [1, 2, 3],
+            config=PaginationConfig(paginator=Paginator([1, 2, 3], 2)),
+        )
         assert response.context_data["page"].number == 2
 
     def test_extra_context_merged(self, rf):
@@ -202,9 +86,9 @@ class TestRenderPaginatedResponse:
         assert response.template_name == "template.html#my-list"
         assert response.context_data["pagination_config"].target == "my-list"
 
-    def test_django_paginator_per_page(self, rf):
+    def test_custom_paginator_per_page(self, rf):
         request = self._make_request(rf)
-        config = PaginationConfig(paginator=DjangoPaginator([1, 2, 3, 4, 5], 2))
+        config = PaginationConfig(paginator=Paginator([1, 2, 3, 4, 5], 2))
         response = render_paginated_response(request, "template.html", [], config=config)
         assert response.context_data["paginator"].per_page == 2
 
@@ -220,6 +104,6 @@ class TestRenderPaginatedResponse:
         request = rf.get("/", {"p": "2"})
         request.htmx = HtmxDetails(request)
         items = list(range(10))
-        config = PaginationConfig(param="p", paginator=ZeroCountPaginator(items, 3))
+        config = PaginationConfig(param="p", paginator=Paginator(items, 3))
         response = render_paginated_response(request, "template.html", items, config=config)
         assert response.context_data["page"].number == 2


### PR DESCRIPTION
## Summary

- Remove `ZeroCountPage`, `ZeroCountPaginator`, `validate_page_number`, and the `Page`/`Paginator` protocols — unnecessary complexity for most use cases
- `render_paginated_response` now defaults to Django's built-in `Paginator`
- Move `ZeroCountPaginator` and `FastCountPaginator` into `docs/Pagination.md` as copy-paste optimization patterns for large datasets
- Add PEP 758 (`except` without parentheses) note to `AGENTS.md` to prevent AI assistants reverting valid Python 3.14 syntax

## Test plan

- [ ] All 107 tests pass (`just check`)
- [ ] `paginator.py` renders cleanly via pre-commit ruff checks
- [ ] `Pagination.md` Performance Optimizations section contains both patterns with correct Python 3.14 `except` syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)