### PR TITLE
fix: back up generated json files before copier re-render

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -14,6 +14,7 @@ Invoked by copier as:
 
 import datetime
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -75,6 +76,12 @@ def _parse_skill_description(skill_file: Path) -> str:
         if line.startswith("description:"):
             return line.split(":", 1)[1].strip(' "')
     return ""
+
+
+def _backup(src: Path) -> None:
+    """Copy src to /tmp/<name>.bak if it exists, so dj-sync can diff it."""
+    if src.exists():
+        shutil.copy2(src, Path("/tmp") / f"{src.name.lstrip('.')}.bak")
 
 
 def install_claude_hooks() -> None:
@@ -176,6 +183,7 @@ def install_claude_hooks() -> None:
     }
     claude_dir = BASE_DIR / ".claude"
     claude_dir.mkdir(parents=True, exist_ok=True)
+    _backup(claude_dir / "settings.json")
     with (claude_dir / "settings.json").open("w") as f:
         json.dump(settings, f, indent=2)
         f.write("\n")
@@ -199,6 +207,7 @@ def install_claude_hooks() -> None:
             "description": description,
         }
     opencode = {"$schema": "https://opencode.ai/config.json", "command": opencode_commands}
+    _backup(BASE_DIR / "opencode.json")
     with (BASE_DIR / "opencode.json").open("w") as f:
         json.dump(opencode, f, indent=2)
         f.write("\n")
@@ -230,6 +239,7 @@ def install_mcp_config() -> None:
             },
         }
     }
+    _backup(BASE_DIR / ".mcp.json")
     with (BASE_DIR / ".mcp.json").open("w") as f:
         json.dump(config, f, indent=2)
         f.write("\n")

--- a/template/.agents/skills/dj-sync/SKILL.md
+++ b/template/.agents/skills/dj-sync/SKILL.md
@@ -13,10 +13,13 @@ any merge conflicts interactively.
 uvx copier update --trust
 ```
 
-This pulls the latest template into the project and stages the merged files.
-If there are no conflicts, skip to Step 4.
+The post-gen hook automatically backs up `.claude/settings.json`, `.mcp.json`,
+and `opencode.json` to `/tmp/*.bak` before regenerating them.
 
-### 2. Detect conflicts
+This pulls the latest template into the project and stages the merged files.
+If there are no conflicts, skip to Step 3.
+
+### 2. Detect and resolve conflicts
 
 Check for merge conflicts introduced by the update:
 
@@ -30,8 +33,6 @@ List any files with conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`):
 grep -rn "<<<<<<" . --include="*.py" --include="*.html" --include="*.jinja" \
     --include="*.yml" --include="*.toml" --include="*.md" 2>/dev/null
 ```
-
-### 3. Resolve each conflict interactively
 
 For every conflicted file:
 
@@ -49,6 +50,26 @@ For every conflicted file:
 4. Apply the user's decision and remove the conflict markers.
 
 Repeat until no conflict markers remain.
+
+### 3. Restore local overrides in generated files
+
+Diff the auto-generated backups against the freshly regenerated files:
+
+```bash
+diff /tmp/settings.json.bak .claude/settings.json
+diff /tmp/mcp.json.bak .mcp.json
+diff /tmp/opencode.json.bak opencode.json
+```
+
+For each file with a non-empty diff:
+
+1. Show the diff to the user.
+2. Identify which lines are new template additions vs. local customizations
+   the user had made (e.g. extra `permissions.allow` entries, extra MCP
+   servers such as `kubernetes`).
+3. Ask the user which local customizations to restore, then apply them.
+
+If the backup files don't exist (first sync on a fresh project), skip this step.
 
 ### 4. Verify
 

--- a/template/.dockerignore
+++ b/template/.dockerignore
@@ -26,6 +26,7 @@ opencode.json
 .venv
 .vim
 .vscode
+*.bak
 .gitignore
 .gitattributes
 .dockerignore

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -41,6 +41,9 @@ locale/**/*.mo
 htmlcov/
 .pytest_cache/
 
+# Temp / backup
+*.bak
+
 # IDEs
 .idea/
 .vscode/

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+from pathlib import Path
 
 import pytest
 
@@ -182,3 +183,49 @@ class TestLicensePrompt:
         project = render(output_dir, {**DEFAULT_CONTEXT, "license": "MIT"})
         content = (project / "LICENSE").read_text()
         assert str(datetime.date.today().year) in content
+
+
+class TestPostGenBackup:
+    """Test that the hook backs up generated files before overwriting on re-render."""
+
+    def test_settings_json_backed_up_on_re_render(self, output_dir):
+        project = render(output_dir, DEFAULT_CONTEXT)
+        original = (project / ".claude" / "settings.json").read_text()
+        bak = Path("/tmp/settings.json.bak")
+        bak.unlink(missing_ok=True)
+
+        render(output_dir, DEFAULT_CONTEXT)
+
+        assert bak.exists()
+        assert bak.read_text() == original
+
+    def test_mcp_json_backed_up_on_re_render(self, output_dir):
+        project = render(output_dir, DEFAULT_CONTEXT)
+        original = (project / ".mcp.json").read_text()
+        bak = Path("/tmp/mcp.json.bak")
+        bak.unlink(missing_ok=True)
+
+        render(output_dir, DEFAULT_CONTEXT)
+
+        assert bak.exists()
+        assert bak.read_text() == original
+
+    def test_opencode_json_backed_up_on_re_render(self, output_dir):
+        project = render(output_dir, DEFAULT_CONTEXT)
+        original = (project / "opencode.json").read_text()
+        bak = Path("/tmp/opencode.json.bak")
+        bak.unlink(missing_ok=True)
+
+        render(output_dir, DEFAULT_CONTEXT)
+
+        assert bak.exists()
+        assert bak.read_text() == original
+
+    def test_no_backup_if_file_absent(self, output_dir):
+        bak = Path("/tmp/settings.json.bak")
+        bak.unlink(missing_ok=True)
+        # Render into a fresh directory — settings.json doesn't exist yet
+        project = render(output_dir, DEFAULT_CONTEXT)
+        assert (project / ".claude" / "settings.json").exists()
+        # The hook should not have created a backup (nothing to back up)
+        assert not bak.exists()


### PR DESCRIPTION
## Summary

- The post-gen hook now copies `.claude/settings.json`, `.mcp.json`, and `opencode.json` to `/tmp/<name>.bak` before overwriting them, so local customisations are not silently lost on `copier update`
- `dj-sync` skill updated to reference these automatic backups and guide the user through a diff/restore step (Step 3)
- `*.bak` added to generated `.gitignore` and `.dockerignore`
- 4 new tests in `TestPostGenBackup` cover backup-on-re-render, no-backup-on-first-render, and content parity

## Test plan

- [ ] All 111 tests pass (`just test`)
- [ ] Re-render an existing project and confirm `/tmp/settings.json.bak`, `/tmp/mcp.json.bak`, `/tmp/opencode.json.bak` appear
- [ ] Fresh render produces no `/tmp/*.bak` files

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)