### PR TITLE
docs: add date/number formatting docs and dj-translate format file step

### DIFF
--- a/template/.agents/skills/dj-translate/SKILL.md
+++ b/template/.agents/skills/dj-translate/SKILL.md
@@ -71,6 +71,38 @@ Common native names: `fr` → Français, `fr_CA` → Français (Canada),
 
 ---
 
+### 2b — Create locale format file *(new locale only — skip if re-running)*
+
+Check whether `config/formats/<locale>/` exists.
+
+If it does not, create it:
+
+```bash
+mkdir -p config/formats/<locale>
+touch config/formats/<locale>/__init__.py
+```
+
+Then create `config/formats/<locale>/formats.py`. Use Django's built-in locale
+formats for `<locale>` (found at `django/conf/locale/<locale>/formats.py` inside
+the installed Django package) as a reference, and write only the overrides that
+differ from Django's defaults or that should be project-specific. At minimum,
+include `DATE_FORMAT` matching the style used in `config/formats/en/formats.py`.
+
+Example for `fr`:
+
+```python
+DATE_FORMAT = "j F Y"
+SHORT_DATE_FORMAT = "d/m/Y"
+DECIMAL_SEPARATOR = ","
+THOUSAND_SEPARATOR = "\xa0"
+NUMBER_GROUPING = 3
+```
+
+See `docs/localization.md#dates-numbers-and-locale-aware-formatting` for the
+full list of available variables.
+
+---
+
 ### 3 — Translate the `.po` file
 
 Read `locale/<locale>/LC_MESSAGES/django.po`.

--- a/template/docs/localization.md
+++ b/template/docs/localization.md
@@ -136,6 +136,83 @@ needed.
 
 ---
 
+## Dates, numbers, and locale-aware formatting
+
+Django's formatting system renders dates, times, and numbers according to the
+active locale when `USE_L10N = True`. This is enabled by default.
+
+`FORMAT_MODULE_PATH = ["config.formats"]` (already set in `config/settings.py`)
+tells Django to look for locale-specific overrides in `config/formats/<locale>/formats.py`
+before falling back to Django's built-in locale formats.
+
+### Format file
+
+Each locale can have a `config/formats/<locale>/formats.py` that overrides the
+built-in defaults. The `en` locale already ships one:
+
+```
+config/formats/
+    en/
+        __init__.py
+        formats.py        # DATE_FORMAT = "j M Y"
+```
+
+To add a new locale (e.g. `fr`):
+
+```bash
+mkdir -p config/formats/fr
+touch config/formats/fr/__init__.py
+```
+
+Then create `config/formats/fr/formats.py` with any overrides:
+
+```python
+# Override Django's built-in French formats as needed.
+# Available variables (see django/conf/locale/<locale>/formats.py for defaults):
+
+DATE_FORMAT = "j F Y"          # 25 mars 2026
+DATETIME_FORMAT = "j F Y H:i"
+TIME_FORMAT = "H:i"
+SHORT_DATE_FORMAT = "d/m/Y"
+
+DECIMAL_SEPARATOR = ","
+THOUSAND_SEPARATOR = "\xa0"    # non-breaking space
+NUMBER_GROUPING = 3
+```
+
+Leave out any variable you want Django's built-in locale default to apply.
+
+### Templates
+
+Use `{{ value|localize }}` to format a value using the active locale:
+
+```html
+{% load l10n %}
+<p>{{ article.published_at|localize }}</p>
+<p>{{ price|localize }}</p>
+```
+
+Wrap a block to force locale-aware output on/off:
+
+```html
+{% load l10n %}
+{% localize on %}
+  {{ price }}
+{% endlocalize %}
+```
+
+### Python
+
+```python
+from django.utils import formats
+
+formats.date_format(value, "DATE_FORMAT")       # uses active locale's DATE_FORMAT
+formats.number_format(value, decimal_pos=2)     # locale-aware decimal/grouping
+formats.localize(value)                         # auto-detects type
+```
+
+---
+
 ## dj-translate skill
 
 Use `/dj-translate <locale>` to extract, translate, and compile a message catalogue in


### PR DESCRIPTION
## Summary

- Adds a new "Dates, numbers, and locale-aware formatting" section to `docs/localization.md` covering `FORMAT_MODULE_PATH`, custom format files, the `localize` template filter, and `django.utils.formats`
- Updates `dj-translate` SKILL.md with a new step 2b (new locales only) to create `config/formats/<locale>/` with `__init__.py` and a `formats.py` seeded with locale-appropriate overrides

Closes #226