### PR TITLE
docs: fix deployment.md link case in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,4 +199,4 @@ Python 3.14 is managed automatically by `uv` - no separate install needed.
 | [kubectl](https://kubernetes.io/docs/tasks/tools/)             | Kubernetes CLI                                      | See install docs |
 | [hcloud](https://github.com/hetznercloud/cli)                  | Hetzner Cloud CLI                                   | See install docs |
 
-See `docs/Deployment.md` in the generated project for full deployment instructions.
+See `docs/deployment.md` in the generated project for full deployment instructions.


### PR DESCRIPTION
`docs/Deployment.md` → `docs/deployment.md` to match the actual filename (lower-kebab-case per naming convention).

The generated project `README.md.jinja` already had the correct casing; this aligns the repo root `README.md`.