### PR TITLE
fix: replace uv-secure with pysentry

### DIFF
--- a/template/.agents/skills/dj-secure/SKILL.md
+++ b/template/.agents/skills/dj-secure/SKILL.md
@@ -273,18 +273,14 @@ literal rather than loaded from the environment:
 
 ### 9. Dependency vulnerabilities
 
-Note: `uv-secure` pre-commit already checks this. Run as a secondary check:
+Note: `pysentry` pre-commit already checks this. Run as a secondary check:
 
 ```bash
-uvx uv-secure
+uvx pysentry-rs
 ```
 
 Flag every reported vulnerability at its upstream severity (CRITICAL/HIGH →
-CRITICAL, MEDIUM → WARNING, LOW → ADVISORY). If `uv-secure` is not available:
-
-```bash
-uvx pip-audit
-```
+CRITICAL, MEDIUM → WARNING, LOW → ADVISORY).
 
 ---
 

--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -90,10 +90,10 @@ repos:
     rev: v0.25
     hooks:
       - id: validate-pyproject
-  # - repo: https://github.com/owenlamont/uv-secure
-  #   rev: 0.17.0
-  #   hooks:
-  #     - id: uv-secure
+  - repo: https://github.com/pysentry/pysentry-pre-commit
+    rev: v0.4.3
+    hooks:
+      - id: pysentry
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.105.0
     hooks:


### PR DESCRIPTION
Replaces the commented-out `uv-secure` hook with `pysentry` (via `pysentry/pysentry-pre-commit`).

- `uv-secure` was disabled due to upstream dependency issues
- `pysentry` is Rust-based, actively maintained, scans `uv.lock` against PyPA Advisory DB + OSV.dev
- Updated `dj-secure` skill to reference `pysentry` instead of `uv-secure`