### PR TITLE
feat: add [tool.pysentry] config to pyproject.toml

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -204,3 +204,13 @@ django_settings_module = "config.settings"
 include = ["{{ package_name }}"]
 exclude = ["**/migrations/*.py", "**/tests/**/*.py"]
 typeCheckingMode = "basic"
+
+[tool.pysentry.defaults]
+severity = "medium"
+# fail_on = "high"
+
+[tool.pysentry.sources]
+# enabled = ["pypa", "osv", "pypi"]
+
+[tool.pysentry.ignore]
+# ids = []


### PR DESCRIPTION
Sets `severity = "medium"` as the active default. All other options (`fail_on`, `sources.enabled`, `ignore.ids`) are included but commented out for easy activation later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)