### PR TITLE
fix: move .env.example inline comments above each variable

### DIFF
--- a/template/.env.example.jinja
+++ b/template/.env.example.jinja
@@ -1,3 +1,4 @@
+# ── Development ───────────────────────────────────────────────────────────────
 # Enable Django debug mode
 DEBUG=true
 # Django secret key
@@ -21,7 +22,6 @@ USE_COLLECTSTATIC=false
 # Django admin URL path
 ADMIN_URL=admin/
 
-# ── Development ───────────────────────────────────────────────────────────────
 # Enable browser auto-reload on code changes (development only)
 USE_BROWSER_RELOAD=true
 # Enable Django Debug Toolbar (development only)


### PR DESCRIPTION
## Summary

- Inline `# comments` after `KEY=` are read as part of the value string by dotenv parsers
- Move each variable's description to the line above it instead
- Deployment vars remain commented out (`# KEY=`) until the user needs them
- All non-deployment vars get a description comment above them

🤖 Generated with [Claude Code](https://claude.com/claude-code)