### PR TITLE
fix: add helm/*/charts/ to .gitignore

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -62,3 +62,4 @@ terraform/**/.terraform.lock.hcl
 
 # Helm
 helm/*/values.secret.yaml
+helm/*/charts/


### PR DESCRIPTION
## Summary

- Add `helm/*/charts/` to `.gitignore` in the generated project template
- These are downloaded dependency tarballs regenerated by `helm dependency build` from `Chart.lock` — build artifacts that should not be committed

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)