### PR TITLE
fix: add mailgun_sender_domain variable to cloudflare terraform

### DIFF
--- a/template/.agents/skills/dj-launch/SKILL.md
+++ b/template/.agents/skills/dj-launch/SKILL.md
@@ -215,9 +215,12 @@ If **yes**:
 Ask:
 > Enter your full Mailgun sender domain (e.g. `mg.example.com`):
 
+Save the full sender domain (e.g. `mg.example.com`) for use in Step 4
+(`app.mailgunSenderDomain` in `values.secret.yaml`).
+
 Extract the subdomain prefix (everything before the first `.`) and set
-`mailgun_sender_domain` in `terraform/cloudflare/terraform.tfvars`. For example,
-`mg.example.com` → `mailgun_sender_domain = "mg"`. The Cloudflare zone handles
+`mailgun_subdomain` in `terraform/cloudflare/terraform.tfvars`. For example,
+`mg.example.com` → `mailgun_subdomain = "mg"`. The Cloudflare zone handles
 the base domain, so only the prefix is needed in tfvars.
 
 Ask:
@@ -241,7 +244,7 @@ If user answers **no**, skip. Tell the user:
 ### 2f. Write terraform.tfvars and apply
 
 Write `terraform/cloudflare/terraform.tfvars` with all collected values, including
-`mailgun_sender_domain`, `mailgun_dkim_value`, and `mailgun_mx_servers` if collected in 2e.
+`mailgun_subdomain`, `mailgun_dkim_value`, and `mailgun_mx_servers` if collected in 2e.
 
 Then:
 ```bash
@@ -422,8 +425,9 @@ For each, only prompt if currently `CHANGE_ME` or empty:
 **Contact email:**
 > Enter the public contact email address:
 
-**Mailgun sender domain** (the `mg.yourdomain.com` subdomain for outbound email):
-> Enter your Mailgun sender domain (e.g. `mg.yourdomain.com`), or type **skip** to leave empty:
+**Mailgun sender domain** — if the user provided a Mailgun sender domain in Step 2e,
+set `app.mailgunSenderDomain` to the full domain (e.g. `mg.example.com`). If Mailgun
+was not configured in Step 2e, skip.
 
 **Admin URL** — generate a random human-readable slug if the user skips:
 

--- a/template/terraform/cloudflare/main.tf.jinja
+++ b/template/terraform/cloudflare/main.tf.jinja
@@ -77,7 +77,7 @@ locals {
 resource "cloudflare_record" "mailgun_mx" {
   count           = local.mailgun_dkim_value != "" ? length(var.mailgun_mx_servers) : 0
   zone_id         = data.cloudflare_zone.domain.id
-  name            = var.mailgun_sender_domain
+  name            = var.mailgun_subdomain
   content         = var.mailgun_mx_servers[count.index]
   type            = "MX"
   priority        = 10
@@ -89,7 +89,7 @@ resource "cloudflare_record" "mailgun_mx" {
 resource "cloudflare_record" "mailgun_spf" {
   count           = local.mailgun_dkim_value != "" ? 1 : 0
   zone_id         = data.cloudflare_zone.domain.id
-  name            = var.mailgun_sender_domain
+  name            = var.mailgun_subdomain
   content         = "\"${var.mailgun_spf_value}\""
   type            = "TXT"
   ttl             = 1
@@ -100,7 +100,7 @@ resource "cloudflare_record" "mailgun_spf" {
 resource "cloudflare_record" "mailgun_dkim" {
   count           = local.mailgun_dkim_value != "" ? 1 : 0
   zone_id         = data.cloudflare_zone.domain.id
-  name            = "mta._domainkey.${var.mailgun_sender_domain}"
+  name            = "mta._domainkey.${var.mailgun_subdomain}"
   content         = "\"${local.mailgun_dkim_value}\""
   type            = "TXT"
   ttl             = 1
@@ -111,7 +111,7 @@ resource "cloudflare_record" "mailgun_dkim" {
 resource "cloudflare_record" "mailgun_tracking" {
   count           = local.mailgun_dkim_value != "" ? 1 : 0
   zone_id         = data.cloudflare_zone.domain.id
-  name            = "email.${var.mailgun_sender_domain}"
+  name            = "email.${var.mailgun_subdomain}"
   content         = "eu.mailgun.org"
   type            = "CNAME"
   proxied         = false

--- a/template/terraform/cloudflare/terraform.tfvars.example.jinja
+++ b/template/terraform/cloudflare/terraform.tfvars.example.jinja
@@ -22,6 +22,6 @@ enable_www_redirect = true
 # grafana_subdomain = "grafana"
 
 # Mailgun configuration (optional)
-# mailgun_sender_domain = "mg"
+# mailgun_subdomain = "mg"
 # mailgun_dkim_value = "k=rsa; p=..."
 # mailgun_mx_servers = ["mxa.eu.mailgun.org", "mxb.eu.mailgun.org"]

--- a/template/terraform/cloudflare/variables.tf.jinja
+++ b/template/terraform/cloudflare/variables.tf.jinja
@@ -38,8 +38,8 @@ variable "grafana_subdomain" {
   default     = ""
 }
 
-variable "mailgun_sender_domain" {
-  description = "Mailgun sender subdomain (e.g. 'mg' → mg.example.com). Leave empty to skip Mailgun DNS."
+variable "mailgun_subdomain" {
+  description = "Subdomain for Mailgun sending (e.g. 'mg' → mg.example.com). Leave empty to skip Mailgun DNS."
   type        = string
   default     = "mg"
 }


### PR DESCRIPTION
## Summary

- Declare `mailgun_sender_domain` variable in the cloudflare terraform module (default: `"mg"`)
- Replace hardcoded `"mg"` in all Mailgun DNS record names with `var.mailgun_sender_domain`
- Add commented-out example to `terraform.tfvars.example`
- Update `/dj-launch` Step 2e to prompt for the subdomain prefix

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)