### PR TITLE
fix: default grafana_subdomain to empty string

### DIFF
--- a/template/.agents/skills/dj-launch-observability/SKILL.md
+++ b/template/.agents/skills/dj-launch-observability/SKILL.md
@@ -55,6 +55,23 @@ printing it. Tell the user:
 
 ---
 
+## Step 1b — Grafana DNS record
+
+Read `terraform/cloudflare/terraform.tfvars`. If `grafana_subdomain` is not set or
+is empty, set it to `"grafana"` and set `monitor_ip` to the server IP:
+
+```bash
+monitor_ip=$(just terraform-value hetzner server_public_ip)
+```
+
+Then re-apply the Cloudflare terraform to create the Grafana DNS record:
+
+```bash
+just terraform cloudflare apply -auto-approve
+```
+
+---
+
 ## Step 2 — Deploy
 
 ```bash

--- a/template/terraform/cloudflare/variables.tf.jinja
+++ b/template/terraform/cloudflare/variables.tf.jinja
@@ -35,7 +35,7 @@ variable "enable_www_redirect" {
 variable "grafana_subdomain" {
   description = "Subdomain for Grafana UI (e.g. 'grafana' → grafana.example.com). Leave empty to skip."
   type        = string
-  default     = "grafana"
+  default     = ""
 }
 
 variable "mailgun_dkim_value" {


### PR DESCRIPTION
## Summary

- Change `grafana_subdomain` default from `"grafana"` to `""` in cloudflare terraform so the Grafana A record is skipped when observability is not configured
- Add Step 1b to `/dj-launch-observability` to set `grafana_subdomain = "grafana"` and `monitor_ip` when deploying the observability stack

Without this, `terraform apply` fails with an invalid IPv4 error because `monitor_ip` is empty.

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)