### PR TITLE
fix(dj-launch): remove redundant migrate from next steps

### DIFF
--- a/template/.agents/skills/dj-launch/SKILL.md
+++ b/template/.agents/skills/dj-launch/SKILL.md
@@ -548,7 +548,6 @@ Then tell the user:
 > Your app is live at https://<domain>
 >
 > Next steps:
-> - Run `just rdj migrate` to apply database migrations
 > - Run `just rdj createsuperuser` to create an admin account
 > - Visit https://<domain>/<admin-url> to access the Django admin
 


### PR DESCRIPTION
## Summary

- Remove `just rdj migrate` from the "Next steps" output in Step 6c — migrations run automatically as part of the `django-release` Helm job
- The `set_default_site` command already includes the required `domain` and `name` arguments in the current skill

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)