### PR TITLE
fix(dj-rotate-secrets): update db/cache passwords before redeploying

### DIFF
--- a/template/.agents/skills/dj-rotate-secrets/SKILL.md
+++ b/template/.agents/skills/dj-rotate-secrets/SKILL.md
@@ -171,7 +171,26 @@ secrets:
   redisPassword: "<new-value>"
 ```
 
-Then deploy:
+### 5a. Update passwords in running services
+
+**Before** redeploying the app, update the passwords in the running database and
+cache services. Otherwise the app will restart with new credentials while the
+services still expect the old ones, causing immediate 500 errors.
+
+**PostgreSQL:**
+```bash
+just kube exec postgres-0 -- bash -c "psql -U postgres -c \"ALTER USER postgres PASSWORD '<new_postgres_password>';\""
+```
+
+**Redis:**
+```bash
+just kube exec deploy/redis -- redis-cli -a "<old_redis_password>" CONFIG SET requirepass "<new_redis_password>"
+```
+
+Replace `<new_postgres_password>`, `<old_redis_password>`, and `<new_redis_password>`
+with the actual values (do not print them to the chat — pipe them from variables).
+
+### 5b. Deploy the app
 
 ```bash
 just deploy-config


### PR DESCRIPTION
## Summary

- Add Step 5a to update passwords in the running PostgreSQL and Redis services before deploying the app with new credentials
- Without this, the app restarts with new passwords while the databases still expect the old ones, causing immediate 500 errors
- Order: ALTER postgres password → CONFIG SET redis password → deploy app

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)