### PR TITLE
fix: move db-backups reminder to post-launch section in dj-launch

### DIFF
--- a/template/.agents/skills/dj-launch/SKILL.md
+++ b/template/.agents/skills/dj-launch/SKILL.md
@@ -638,6 +638,7 @@ Tell the user:
 > **Next steps (optional):**
 > - Run `/dj-launch-observability` to deploy Grafana + Prometheus + Loki
 > - Run `/dj-enable-db-backups` to set up automated daily PostgreSQL backups
+> - Run `/dj-rotate-secrets` to rotate auto-generated secrets when ready
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove the early db-backups reminder from between Step 3 and Step 4
- Add it to Step 7 alongside the observability prompt as a grouped "Next steps (optional)" section
- Both are optional post-launch steps and belong together at the end

Closes #257