### PR TITLE
fix: use direct Helm redeploy instead of full CI deploy in dj-rotate-secrets

### DIFF
--- a/template/.agents/skills/dj-rotate-secrets/SKILL.md
+++ b/template/.agents/skills/dj-rotate-secrets/SKILL.md
@@ -192,12 +192,11 @@ with the actual values (do not print them to the chat — pipe them from variabl
 
 ### 5b. Deploy
 
-Update the GitHub secret so CI stays in sync, then redeploy directly via Helm
-to minimise the window between password changes and the app restart:
+Push updated secrets to GitHub and redeploy directly via Helm (this does not
+trigger a CI build — it applies the Helm chart to the cluster immediately):
 
 ```bash
-gh secret set HELM_VALUES_SECRET < helm/site/values.secret.yaml
-just helm site
+just deploy-config
 ```
 
 Tell the user:


### PR DESCRIPTION
## Summary
- Replace `just deploy-config` with `gh secret set` + `just helm site`
- Minimises the window between password changes and app restart by avoiding the full CI build pipeline

Closes #260