### PR TITLE
feat: Add djlint PostToolUse hook for HTML template auto-lint

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -179,6 +179,15 @@ def install_claude_hooks() -> None:
                                 " — run: just dj makemigrations'; fi"
                             ),
                         },
+                        {
+                            "type": "command",
+                            "command": (
+                                "FILE=$(jq -r '.tool_input.file_path // empty');"
+                                ' if [ -n "$FILE" ]'
+                                " && echo \"$FILE\" | grep -q '\\.html$';"
+                                ' then uv run djlint --lint "$FILE"; fi'
+                            ),
+                        },
                     ],
                 }
             ],


### PR DESCRIPTION
## Summary

- Adds a `PostToolUse` hook that runs `djlint --lint` on `.html` files after each `Edit` or `Write`
- Mirrors the existing ruff hook for Python files — immediate lint feedback without waiting for pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)