### PR TITLE
feat: Add /dj-create-migration skill for data migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,9 @@ Generated projects include `dj-*` Claude Code and OpenCode slash commands for co
 | `/dj-create-task`    | Add a `django-tasks-db` background task with correct async patterns    |
 | `/dj-create-command` | Add a management command with tests                                    |
 | `/dj-create-cron`    | Schedule a management command as a Kubernetes cron job                 |
-| `/dj-create-model`   | Design and write a Django model with factory, fixture, and model tests |
-| `/dj-create-crud`    | Generate full CRUD views, templates, URLs, and tests                   |
+| `/dj-create-model`     | Design and write a Django model with factory, fixture, and model tests |
+| `/dj-create-migration` | Create a data migration (Python or SQL)                                |
+| `/dj-create-crud`      | Generate full CRUD views, templates, URLs, and tests                   |
 | `/dj-create-e2e`     | Write Playwright E2E test(s) for a described user interaction          |
 | `/dj-create-tag`     | Add a template tag (simple_tag, simple_block_tag, inclusion_tag, Node) |
 | `/dj-create-filter`  | Add a template filter with correct escaping flags                      |

--- a/template/.agents/skills/dj-create-migration/SKILL.md
+++ b/template/.agents/skills/dj-create-migration/SKILL.md
@@ -1,0 +1,139 @@
+---
+description: Create an empty Django data migration (Python or SQL) for an app
+---
+
+Create a Django data migration for `<app>`.
+
+**Never write migration files by hand.** Always generate the empty file first:
+
+```bash
+just dj makemigrations --empty --name <name> <app>
+```
+
+Then fill in the operation — this keeps Django's dependency graph intact.
+
+---
+
+### Step 1 — Determine the migration name
+
+If `<name>` was provided, use it as-is.
+
+If not, ask the user:
+
+> What does this migration do? (used to generate the migration name)
+
+Derive a `snake_case` name from the answer (e.g. `backfill_user_display_names`).
+
+---
+
+### Step 2 — Generate the empty migration file
+
+```bash
+just dj makemigrations --empty --name <name> <app>
+```
+
+This creates the file at `<package_name>/<app>/migrations/<NNNN>_<name>.py` with
+the correct dependency chain. Read the generated file to confirm the path and
+dependencies before editing.
+
+---
+
+### Step 3 — Choose the operation type
+
+Ask the user:
+
+> Should this migration use Python (`RunPython`) or raw SQL (`RunSQL`)?
+
+- **Python** — for ORM-based data transforms, row-by-row logic, or anything that
+  needs the application layer.
+- **SQL** — for bulk updates, index creation, triggers, or anything more efficient
+  as a single statement.
+
+---
+
+### Step 4 — Ask for functionality
+
+Ask the user:
+
+> Describe what the migration should do, or type **skip** to leave the
+> implementation empty (you'll fill it in manually).
+
+If the user skips, write a `pass` body (or empty SQL string) and note that the
+implementation is intentionally left blank. Do not invent logic.
+
+---
+
+### Step 5 — Ask about reversibility
+
+Ask the user:
+
+> Should this migration be reversible? [y/n]
+
+- **Yes** — implement a `reverse_sql` string (SQL) or a `reverse_func` (Python)
+  that undoes the forward operation. Ask the user what the reverse should do if
+  not obvious.
+- **No** — use the appropriate noop:
+  - Python: `reverse_func=migrations.RunPython.noop`
+  - SQL: `reverse_sql=migrations.RunSQL.noop`
+
+---
+
+### Step 6 — Write the migration
+
+Edit the generated file. Do not change `dependencies` or `initial`.
+
+**Python template:**
+
+```python
+from django.db import migrations
+
+
+def forward(apps, schema_editor):
+    <model> = apps.get_model("<app>", "<ModelName>")
+    # implementation
+
+
+def reverse(apps, schema_editor):
+    # reverse implementation (or omit if using noop)
+
+
+class Migration(migrations.Migration):
+    dependencies = [...]  # leave as generated
+
+    operations = [
+        migrations.RunPython(forward, reverse_func=migrations.RunPython.noop),
+    ]
+```
+
+**SQL template:**
+
+```python
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [...]  # leave as generated
+
+    operations = [
+        migrations.RunSQL(
+            sql="<forward SQL>",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]
+```
+
+Key rules:
+- Always use `apps.get_model()` — never import models directly in `RunPython`
+  functions (the historical model state may differ from the current model).
+- For large tables, consider `atomic = False` on the `Migration` class and use
+  `schema_editor.connection.cursor()` for batching — ask the user if the table
+  is expected to have more than ~100k rows.
+
+---
+
+### Step 7 — Verify
+
+```bash
+just dj migrate --run-syncdb
+just check-all
+```

--- a/template/.agents/skills/dj-create-migration/resources/help.md
+++ b/template/.agents/skills/dj-create-migration/resources/help.md
@@ -1,0 +1,16 @@
+**/dj-create-migration <app> [name]**
+
+Creates a Django data migration for the given app.
+
+Generates an empty migration file via `makemigrations --empty` (never writes
+the file manually), then fills in a `RunPython` or `RunSQL` operation based on
+your choice. Prompts for reversibility — adds `noop` if not reversible. You can
+type **skip** to leave the implementation empty and fill it in yourself.
+
+Arguments:
+  `<app>`   — the Django app to create the migration in (required)
+  `[name]`  — snake_case name for the migration (optional; prompted if omitted)
+
+Examples:
+  /dj-create-migration orders
+  /dj-create-migration orders backfill_order_totals

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -158,6 +158,7 @@ Available in Claude Code and OpenCode as `/dj-<command>`.
 | `/dj-create-command <app_name> [desc]` | Add a management command with tests |
 | `/dj-create-cron <app_name> <command>` | Schedule a management command as a Kubernetes cron job |
 | `/dj-create-model <app_name> <model>` | Design a model with factory, fixture, and tests |
+| `/dj-create-migration <app_name> [name]` | Create a data migration (Python or SQL) |
 | `/dj-create-crud <app_name> <model>` | Full CRUD views, templates, URLs, forms, and tests |
 | `/dj-create-e2e [<app_name>] <description>` | Write Playwright E2E test(s) for a described interaction |
 | `/dj-create-tag [<app_name>] [<module>]` | Add a template tag |

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -71,8 +71,9 @@ Available in Claude Code and OpenCode as `/dj-<command>`:
 | `/dj-create-task`    | Add a `django-tasks-db` background task with correct async patterns    |
 | `/dj-create-command` | Add a management command with tests                                    |
 | `/dj-create-cron`    | Schedule a management command as a Kubernetes cron job                 |
-| `/dj-create-model`   | Design and write a Django model with factory, fixture, and model tests |
-| `/dj-create-crud`    | Generate full CRUD views, templates, URLs, and tests                   |
+| `/dj-create-model`     | Design and write a Django model with factory, fixture, and model tests |
+| `/dj-create-migration` | Create a data migration (Python or SQL)                                |
+| `/dj-create-crud`      | Generate full CRUD views, templates, URLs, and tests                   |
 | `/dj-create-e2e`     | Write Playwright E2E test(s) for a described user interaction          |
 | `/dj-create-tag`     | Add a template tag (simple_tag, simple_block_tag, inclusion_tag, Node) |
 | `/dj-create-filter`  | Add a template filter with correct escaping flags                      |


### PR DESCRIPTION
## Summary

- Adds `/dj-create-migration <app> [name]` skill for creating Django data migrations
- Generates the empty migration file via `makemigrations --empty --name` (never writes by hand)
- Prompts for Python (`RunPython`) or SQL (`RunSQL`) operation type
- Prompts for reversibility — adds `noop` if not reversible
- Includes a skip option to leave the implementation empty for manual completion
- Updates skill tables in `AGENTS.md.jinja`, `README.md`, and `template/README.md.jinja`

🤖 Generated with [Claude Code](https://claude.com/claude-code)