### PR TITLE
fix(dj-create-migration): Fix reverse_code kwarg and silent migrate

### DIFF
--- a/template/.agents/skills/dj-create-migration/SKILL.md
+++ b/template/.agents/skills/dj-create-migration/SKILL.md
@@ -69,11 +69,11 @@ Ask the user:
 
 > Should this migration be reversible? [y/n]
 
-- **Yes** — implement a `reverse_sql` string (SQL) or a `reverse_func` (Python)
+- **Yes** — implement a `reverse_sql` string (SQL) or a `reverse_code` function (Python)
   that undoes the forward operation. Ask the user what the reverse should do if
   not obvious.
 - **No** — use the appropriate noop:
-  - Python: `reverse_func=migrations.RunPython.noop`
+  - Python: `reverse_code=migrations.RunPython.noop`
   - SQL: `reverse_sql=migrations.RunSQL.noop`
 
 ---
@@ -101,7 +101,7 @@ class Migration(migrations.Migration):
     dependencies = [...]  # leave as generated
 
     operations = [
-        migrations.RunPython(forward, reverse_func=migrations.RunPython.noop),
+        migrations.RunPython(forward, reverse_code=migrations.RunPython.noop),
     ]
 ```
 
@@ -133,7 +133,18 @@ Key rules:
 
 ### Step 7 — Verify
 
+Ask the user:
+
+> Run `migrate` now to apply this migration? [y/n]
+
+If yes:
+
 ```bash
 just dj migrate --run-syncdb
+```
+
+Then:
+
+```bash
 just check-all
 ```

--- a/template/.agents/skills/dj-create-migration/SKILL.md
+++ b/template/.agents/skills/dj-create-migration/SKILL.md
@@ -140,7 +140,7 @@ Ask the user:
 If yes:
 
 ```bash
-just dj migrate --run-syncdb
+just dj migrate
 ```
 
 Then:


### PR DESCRIPTION
Fix two bugs in the `/dj-create-migration` skill.

`RunPython` used `reverse_func=` as the keyword argument, but Django 6.0
renamed this parameter to `reverse_code=`. Any migration generated from the
skill template would raise `TypeError` at runtime.

Step 7 also ran `just dj migrate` automatically without asking. Migrations
should never be applied silently — the skill now prompts before running.

Also drops the unnecessary `--run-syncdb` flag from the migrate command;
that flag syncs unmanaged apps and has no relevance to data migrations.

Fixes #273