### PR TITLE
fix(dj-launch): Add one-sub-step-at-a-time warning

### DIFF
--- a/template/.agents/skills/dj-launch/SKILL.md
+++ b/template/.agents/skills/dj-launch/SKILL.md
@@ -5,6 +5,8 @@ description: Interactive first-deploy wizard: provisions infra, configures secre
 Interactive first-deploy wizard. Guides the user through provisioning infrastructure,
 configuring secrets, and deploying the application end-to-end.
 
+**IMPORTANT: Execute one sub-step at a time. Wait for user confirmation before proceeding to the next sub-step. Do not batch multiple questions or actions into a single response.**
+
 ## Required reading
 
 - `docs/infrastructure.md`


### PR DESCRIPTION
## Summary\n\n- Adds a bolded warning near the top of the `/dj-launch` skill instructing the agent to execute one sub-step at a time and wait for user confirmation before proceeding.\n\nCloses #275\n\nCo-Authored-By: Claude <noreply@anthropic.com>