### PR TITLE
fix(dj-launch): Skip Kubernetes MCP offer if already in .mcp.json

### DIFF
--- a/template/.agents/skills/dj-launch/SKILL.md
+++ b/template/.agents/skills/dj-launch/SKILL.md
@@ -620,6 +620,9 @@ Diagnose and help the user fix the issue before declaring success.
 
 ## Step 6d — Kubernetes MCP
 
+**Pre-check:** Read `.mcp.json` and check whether it already contains a `kubernetes`
+key under `mcpServers`. If it does, skip this step entirely — do not prompt the user.
+
 Now that the cluster is live, offer to add the Kubernetes MCP server to `.mcp.json`
 so AI assistants can inspect pods, logs, and deployments directly.
 


### PR DESCRIPTION
## Summary\n\n- Add a pre-check at the start of step 6d in `/dj-launch` that reads `.mcp.json` and checks for an existing `kubernetes` key under `mcpServers`. If found, the step is skipped entirely without prompting the user.\n\nCloses #278\n\nCo-Authored-By: Claude <noreply@anthropic.com>