### PR TITLE
fix(docs): Correct sorl-thumbnail S3 warning in images.md

### DIFF
--- a/template/docs/images.md
+++ b/template/docs/images.md
@@ -23,15 +23,21 @@ See `docs/cron-jobs.md` for instructions on adding cron jobs.
 If you use sorl-thumbnail with S3 storage (see `docs/file-storage.md`), there are
 several important behaviours to be aware of:
 
-### Management commands are unreliable with S3
+### `thumbnail cleanup` is safe with S3
 
-The `thumbnail cleanup`, `thumbnail clear`, `thumbnail clear_delete_all`, and
-`thumbnail clear_delete_referenced` management commands use `storage.listdir()`
-internally. This does not work correctly with all S3-compatible backends, including
-Hetzner Object Storage. These commands will complete without errors but will **not**
-delete thumbnail files from S3.
+The `thumbnail cleanup` command only prunes stale entries from the cache index (the
+key-value store). It does not delete any files from storage, so it works correctly
+with S3 backends.
 
-Do not rely on management commands for thumbnail cleanup in production S3 setups.
+### `clear_delete_all` and `clear_delete_referenced` are unreliable with S3
+
+The `thumbnail clear_delete_all` and `thumbnail clear_delete_referenced` management
+commands delete actual thumbnail files from storage using `storage.listdir()`. This
+does not work correctly with all S3-compatible backends, including Hetzner Object
+Storage. These commands will complete without errors but will **not** delete thumbnail
+files from S3.
+
+Do not rely on these commands for file deletion in production S3 setups.
 
 ### Thumbnail cleanup on model deletion works via signal
 


### PR DESCRIPTION
## Summary\n\n- Clarify that `thumbnail cleanup` is safe with S3 since it only prunes the cache index, not actual files\n- Move the S3 unreliability warning to apply only to `clear_delete_all` and `clear_delete_referenced`, which delete actual thumbnail files from storage\n\nCloses #279\n\nCo-Authored-By: Claude <noreply@anthropic.com>