### PR TITLE
fix(dj-create-cron): Distinguish custom vs third-party commands in step 8

### DIFF
--- a/template/.agents/skills/dj-create-cron/SKILL.md
+++ b/template/.agents/skills/dj-create-cron/SKILL.md
@@ -119,29 +119,44 @@ just check-all
 
 ---
 
-## Step 8 — Prompt to ship via CI
+## Step 8 — Prompt to deploy
 
 Check whether `helm/site/values.secret.yaml` exists (indicating the project has
 already been deployed to production).
 
-If it exists, remind the user:
+If it does not exist, no action needed here — the cron job will be created when
+the project is first deployed via `/dj-launch`.
 
-> The cron job entry is in `values.yaml` but won't be live until CI deploys it.
-> CI builds the Docker image (which must include the management command) and runs
-> `helm upgrade` together — this ensures the cron job and the command it calls are
-> deployed atomically.
->
-> Once all tests pass, commit and push. CI will handle the rest.
->
-> If GitHub Actions secrets haven't been set up yet (or have changed), run this
-> before pushing:
-> ```bash
-> just gh-set-secrets
-> ```
+If it exists, check whether the management command is a **custom project command**
+or a **third-party command**:
 
-Do NOT suggest running `just deploy` manually — that would deploy the Helm chart
-without a freshly built image and could register a cron job for a command that
-doesn't exist in the running container.
+- **Custom project command** — file exists at
+  `<package_name>/<app_name>/management/commands/<command_name>.py`:
 
-If `values.secret.yaml` does not exist, no action needed here — the cron job will
-be created when the project is first deployed via `/dj-launch`.
+  > The cron job entry is in `values.yaml` but won't be live until CI deploys it.
+  > CI builds the Docker image (which must include the management command) and runs
+  > `helm upgrade` together — this ensures the cron job and the command it calls are
+  > deployed atomically.
+  >
+  > Once all tests pass, commit and push. CI will handle the rest.
+  >
+  > If GitHub Actions secrets haven't been set up yet (or have changed), run this
+  > before pushing:
+  > ```bash
+  > just gh-set-secrets
+  > ```
+
+  Do NOT suggest running `just deploy` or `just deploy-config` manually — that
+  would deploy the Helm chart without a freshly built image and could register a
+  cron job for a command that doesn't exist in the running container.
+
+- **Third-party command** — no project file (the command is already in the
+  container image via an installed package):
+
+  > The command is provided by a third-party package already in the container
+  > image — no new build is needed. Run:
+  > ```bash
+  > just deploy-config
+  > ```
+  > This applies the updated `values.yaml` directly via `helm upgrade` without
+  > triggering a full CI build.

--- a/template/.agents/skills/dj-create-cron/SKILL.md
+++ b/template/.agents/skills/dj-create-cron/SKILL.md
@@ -133,22 +133,19 @@ or a **third-party command**:
 - **Custom project command** — file exists at
   `<package_name>/<app_name>/management/commands/<command_name>.py`:
 
-  > The cron job entry is in `values.yaml` but won't be live until CI deploys it.
-  > CI builds the Docker image (which must include the management command) and runs
-  > `helm upgrade` together — this ensures the cron job and the command it calls are
-  > deployed atomically.
-  >
-  > Once all tests pass, commit and push. CI will handle the rest.
-  >
-  > If GitHub Actions secrets haven't been set up yet (or have changed), run this
-  > before pushing:
-  > ```bash
-  > just gh-set-secrets
-  > ```
+  Ask the user to commit and push the change (or offer to do it for them), then
+  ask how they want to deploy:
 
-  Do NOT suggest running `just deploy` or `just deploy-config` manually — that
-  would deploy the Helm chart without a freshly built image and could register a
-  cron job for a command that doesn't exist in the running container.
+  > How would you like to deploy?
+  > 1. **Deploy through CI** — `just gh deploy` (recommended: builds a fresh Docker
+  >    image containing the new command, then runs `helm upgrade` atomically)
+  > 2. **Deploy config immediately** — `just deploy-config` (applies the Helm chart
+  >    now, but the command must already be in the running container image)
+
+  Recommend option 1 unless the user has a reason to skip CI.
+
+  If GitHub Actions secrets haven't been set up yet (or have changed), remind the
+  user to run `just gh-set-secrets` before deploying.
 
 - **Third-party command** — no project file (the command is already in the
   container image via an installed package):


### PR DESCRIPTION
## Summary\n\n- Step 8 of `/dj-create-cron` now checks whether the management command file exists in the project directory\n- **Custom project commands** (file exists): advises commit-and-push for a full CI build (unchanged behavior)\n- **Third-party commands** (no project file): advises `just deploy-config` to apply the Helm chart directly, since the command is already in the container image\n\nCloses #280