### PR TITLE
feat: Add dj-scale-up and dj-scale-down deployment skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Generated projects include `dj-*` Claude Code and OpenCode slash commands for co
 | `/dj-launch`               | Interactive first-deploy wizard: provisions infra, configures secrets, deploys |
 | `/dj-launch-observability` | Deploy the observability stack (Grafana + Prometheus + Loki)                   |
 | `/dj-rotate-secrets`       | Rotate auto-generated and third-party Helm secrets and redeploy                |
+| `/dj-scale-up`             | Scale up django-app replicas and provision Hetzner nodes if needed              |
+| `/dj-scale-down`           | Scale down django-app replicas and optionally remove Hetzner nodes             |
 | `/dj-enable-db-backups`    | Enable automated daily PostgreSQL backups to a private Object Storage bucket   |
 
 ## MCP Servers

--- a/template/.agents/skills/dj-scale-down/SKILL.md
+++ b/template/.agents/skills/dj-scale-down/SKILL.md
@@ -1,0 +1,125 @@
+---
+description: Scale down django-app replicas and optionally remove Hetzner nodes
+---
+
+Scale the number of `django-app` replicas down to a target count. Warns about
+availability risks, updates the Helm values, redeploys, and optionally removes
+excess Hetzner nodes via Terraform to reduce costs.
+
+## Required reading
+
+- `docs/infrastructure.md`
+- `docs/deployment.md`
+
+---
+
+**Terraform rule:** Never use `cd terraform/<dir>` — always use
+`terraform -chdir=terraform/<dir>` or the `just terraform <dir>` wrapper.
+
+**Secret handling rules:**
+- Never echo, print, or repeat a secret value in the terminal or chat.
+- Check presence only — report missing values by field name, not by value.
+
+---
+
+## Step 1 — Read current state
+
+Read `helm/site/values.secret.yaml` and extract the current `replicas` value.
+
+Read `terraform/hetzner/terraform.tfvars` and extract the current `server_count`
+(defaults to 1 if not set).
+
+Tell the user:
+
+> **Current state:**
+> - Replicas: <current_replicas>
+> - Hetzner nodes: <current_server_count>
+>
+> **Target:** <n> replicas
+
+## Step 2 — Validate and warn
+
+If `<n>` is greater than or equal to the current replica count, tell the user:
+
+> Target (<n>) is not lower than current replicas (<current>).
+> Use `/dj-scale-up` to increase replicas.
+
+Stop.
+
+If `<n>` is 0, warn:
+
+> **WARNING:** Scaling to 0 replicas will make the application completely
+> unavailable. Are you sure? (y/n)
+
+If `<n>` is 1, warn:
+
+> **WARNING:** Running with 1 replica means zero redundancy — a single pod
+> failure will cause downtime. Consider keeping at least 2 replicas for
+> availability. Continue? (y/n)
+
+If the user says **n** to any warning, stop.
+
+Otherwise, ask:
+
+> Proceed with scaling down to <n> replicas? (y/n)
+
+If **n**, stop.
+
+## Step 3 — Update replicas in Helm values
+
+Edit `helm/site/values.secret.yaml` and set `replicas` to `<n>`.
+
+## Step 4 — Deploy
+
+```bash
+just deploy-config
+```
+
+This pushes the updated secret to GitHub Actions and applies the Helm chart.
+
+## Step 5 — Remove excess Hetzner nodes (optional)
+
+After the deploy succeeds, check whether fewer nodes are now needed. A
+reasonable heuristic: each node can run ~2 app replicas.
+
+If the current `server_count` exceeds what `<n>` replicas require:
+
+> You now have <current_server_count> Hetzner nodes but only need
+> <new_server_count> for <n> replicas. Removing <excess> node(s) will
+> reduce your hosting costs.
+>
+> Remove excess nodes via Terraform? (y/n)
+
+If **y**:
+
+```bash
+# Update server_count in terraform.tfvars
+# (edit the file, do not overwrite other values)
+```
+
+```bash
+just terraform hetzner plan
+```
+
+Show the plan. Ask for final confirmation, then:
+
+```bash
+just terraform hetzner apply -auto-approve
+```
+
+After apply, fetch the updated kubeconfig:
+
+```bash
+just get-kubeconfig
+```
+
+If **n**, skip — tell the user they can remove nodes later.
+
+## Step 6 — Summary
+
+Tell the user:
+
+> **Scale-down complete.**
+> Replicas: <old> -> <n>
+>
+> Verify with: `just kube get pods`

--- a/template/.agents/skills/dj-scale-down/resources/help.md
+++ b/template/.agents/skills/dj-scale-down/resources/help.md
@@ -1,0 +1,13 @@
+**/dj-scale-down <n>**
+
+Scale the number of `django-app` replicas down to `<n>`. Shows the current
+replica count, warns if scaling to 0 (unavailable) or 1 (no redundancy),
+asks for confirmation, updates `replicas` in `helm/site/values.secret.yaml`,
+runs `just deploy-config` to apply, and optionally removes excess Hetzner
+nodes via Terraform to reduce costs.
+
+Requires: `terraform`, `helm`, `kubectl`, and `just` installed and
+authenticated. The project must have been deployed with `/dj-launch` first.
+
+Example:
+  /dj-scale-down 2

--- a/template/.agents/skills/dj-scale-up/SKILL.md
+++ b/template/.agents/skills/dj-scale-up/SKILL.md
@@ -1,0 +1,112 @@
+---
+description: Scale up django-app replicas and provision Hetzner nodes if needed
+---
+
+Scale the number of `django-app` replicas up to a target count. Provisions
+additional Hetzner nodes via Terraform if the cluster does not have enough
+capacity, then updates the Helm values and redeploys.
+
+## Required reading
+
+- `docs/infrastructure.md`
+- `docs/deployment.md`
+
+---
+
+**Terraform rule:** Never use `cd terraform/<dir>` — always use
+`terraform -chdir=terraform/<dir>` or the `just terraform <dir>` wrapper.
+
+**Secret handling rules:**
+- Never echo, print, or repeat a secret value in the terminal or chat.
+- Check presence only — report missing values by field name, not by value.
+
+---
+
+## Step 1 — Read current state
+
+Read `helm/site/values.secret.yaml` and extract the current `replicas` value.
+
+Read `terraform/hetzner/terraform.tfvars` and extract the current `server_count`
+(defaults to 1 if not set).
+
+Tell the user:
+
+> **Current state:**
+> - Replicas: <current_replicas>
+> - Hetzner nodes: <current_server_count>
+>
+> **Target:** <n> replicas
+>
+> Proceed? (y/n)
+
+If the user says **n**, stop.
+
+## Step 2 — Validate
+
+If `<n>` is less than or equal to the current replica count, tell the user:
+
+> Target (<n>) is not higher than current replicas (<current>).
+> Use `/dj-scale-down` to reduce replicas.
+
+Stop.
+
+## Step 3 — Provision additional Hetzner nodes (if needed)
+
+Estimate whether additional nodes are needed. A reasonable heuristic: each
+node can run ~2 app replicas (adjust based on resource requests in the Helm
+chart if visible).
+
+If `<n>` requires more nodes than `server_count`:
+
+1. Calculate the new `server_count` (e.g. `ceil(n / 2)`).
+2. Tell the user:
+
+> Scaling to <n> replicas requires <new_server_count> Hetzner nodes
+> (currently <current_server_count>). This will provision
+> <new - current> additional node(s).
+>
+> Proceed with Terraform apply? (y/n)
+
+If **y**:
+
+```bash
+# Update server_count in terraform.tfvars
+# (edit the file, do not overwrite other values)
+```
+
+```bash
+just terraform hetzner plan
+```
+
+Show the plan. Ask for final confirmation, then:
+
+```bash
+just terraform hetzner apply -auto-approve
+```
+
+After apply, add new nodes to SSH known hosts and fetch the updated kubeconfig:
+
+```bash
+just get-kubeconfig
+```
+
+If **n**, stop.
+
+## Step 4 — Update replicas in Helm values
+
+Edit `helm/site/values.secret.yaml` and set `replicas` to `<n>`.
+
+## Step 5 — Deploy
+
+```bash
+just deploy-config
+```
+
+This pushes the updated secret to GitHub Actions and applies the Helm chart.
+
+Tell the user:
+
+> **Scale-up complete.**
+> Replicas: <old> -> <n>
+>
+> Verify with: `just kube get pods`

--- a/template/.agents/skills/dj-scale-up/resources/help.md
+++ b/template/.agents/skills/dj-scale-up/resources/help.md
@@ -1,0 +1,12 @@
+**/dj-scale-up <n>**
+
+Scale the number of `django-app` replicas up to `<n>`. Shows the current
+replica count, asks for confirmation, provisions additional Hetzner nodes
+via Terraform if the cluster needs more capacity, updates `replicas` in
+`helm/site/values.secret.yaml`, and runs `just deploy-config` to apply.
+
+Requires: `terraform`, `helm`, `kubectl`, and `just` installed and
+authenticated. The project must have been deployed with `/dj-launch` first.
+
+Example:
+  /dj-scale-up 4

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -188,6 +188,8 @@ Available in Claude Code and OpenCode as `/dj-<command>`.
 | `/dj-launch` | Interactive first-deploy wizard (infra → secrets → deploy) |
 | `/dj-launch-observability` | Deploy the observability stack (Grafana + Prometheus + Loki) |
 | `/dj-rotate-secrets` | Rotate auto-generated and third-party Helm secrets and redeploy |
+| `/dj-scale-up` | Scale up django-app replicas and provision Hetzner nodes if needed |
+| `/dj-scale-down` | Scale down django-app replicas and optionally remove Hetzner nodes |
 | `/dj-enable-db-backups` | Enable automated daily PostgreSQL backups to Object Storage |
 
 

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -102,6 +102,8 @@ Available in Claude Code and OpenCode as `/dj-<command>`:
 | `/dj-launch`               | Interactive first-deploy wizard: provisions infra, configures secrets, deploys |
 | `/dj-launch-observability` | Deploy the observability stack (Grafana + Prometheus + Loki)                   |
 | `/dj-rotate-secrets`       | Rotate auto-generated and third-party Helm secrets and redeploy                |
+| `/dj-scale-up`             | Scale up django-app replicas and provision Hetzner nodes if needed              |
+| `/dj-scale-down`           | Scale down django-app replicas and optionally remove Hetzner nodes             |
 | `/dj-enable-db-backups`    | Enable automated daily PostgreSQL backups to a private Object Storage bucket   |
 
 ## MCP Servers


### PR DESCRIPTION
## Summary

- Add `/dj-scale-up <n>` skill to scale django-app replicas up, provisioning additional Hetzner nodes via Terraform when needed
- Add `/dj-scale-down <n>` skill to scale django-app replicas down with availability warnings (0 or 1 replica), optionally removing excess Hetzner nodes to reduce costs
- Update command tables in `template/AGENTS.md.jinja`, `template/README.md.jinja`, and `README.md`

Closes #282

## Test plan

- [ ] Verify generated project includes `.agents/skills/dj-scale-up/` and `.agents/skills/dj-scale-down/` with SKILL.md and resources/help.md
- [ ] Verify post-gen hook auto-discovers both skills and generates command stubs
- [ ] Verify command tables in all three docs are consistent and properly formatted