### PR TITLE
fix(dj-launch): Set KUBECONFIG env in kubernetes MCP entry

### DIFF
--- a/template/.agents/skills/resources/add-kube-mcp.py
+++ b/template/.agents/skills/resources/add-kube-mcp.py
@@ -4,14 +4,33 @@
 Idempotent — safe to run multiple times. Does nothing if the entry
 already exists with a non-empty configuration.
 
+Sets KUBECONFIG to ~/.kube/<project_slug>.yaml so the MCP server
+uses the project-specific kubeconfig instead of the default context.
+
 Usage:
     uv run python .agents/skills/resources/add-kube-mcp.py
 """
 
 import json
+import re
 from pathlib import Path
 
 MCP_FILE = Path(".mcp.json")
+COPIER_ANSWERS = Path(".copier-answers.yml")
+
+
+def get_project_slug() -> str:
+    """Read project_slug from .copier-answers.yml."""
+    text = COPIER_ANSWERS.read_text()
+    match = re.search(r"^project_slug:\s*(.+)$", text, re.MULTILINE)
+    if not match:
+        msg = "project_slug not found in .copier-answers.yml"
+        raise ValueError(msg)
+    return match.group(1).strip()
+
+
+slug = get_project_slug()
+kubeconfig_path = f"~/.kube/{slug}.yaml"
 
 config = json.loads(MCP_FILE.read_text())
 servers = config.setdefault("mcpServers", {})
@@ -22,6 +41,9 @@ else:
     servers["kubernetes"] = {
         "command": "npx",
         "args": ["-y", "mcp-server-kubernetes"],
+        "env": {
+            "KUBECONFIG": kubeconfig_path,
+        },
     }
     MCP_FILE.write_text(json.dumps(config, indent=2) + "\n")
-    print("kubernetes MCP server added to .mcp.json")
+    print(f"kubernetes MCP server added to .mcp.json (KUBECONFIG={kubeconfig_path})")

--- a/template/docs/mcp.md
+++ b/template/docs/mcp.md
@@ -57,9 +57,10 @@ Starts a Django shell session with the full application context loaded
 
 **Package:** `mcp-server-kubernetes`
 
-Uses your current `kubectl` context (configured by `just get-kubeconfig` during
-`/dj-launch`). Added to `.mcp.json` at the end of the launch wizard — not present
-in fresh projects.
+Uses the project-specific kubeconfig at `~/.kube/<project_slug>.yaml` (configured
+by `just get-kubeconfig` during `/dj-launch`). The `KUBECONFIG` env var is set in
+the MCP entry so the server uses the correct cluster context. Added to `.mcp.json`
+at the end of the launch wizard — not present in fresh projects.
 
 **Use for:**
 - Checking pod status and events: `kubectl get pods`
@@ -70,16 +71,7 @@ in fresh projects.
 To add it manually after launch:
 
 ```bash
-python3 -c "
-import json, pathlib
-p = pathlib.Path('.mcp.json')
-config = json.loads(p.read_text())
-config['mcpServers']['kubernetes'] = {
-    'command': 'npx',
-    'args': ['-y', 'mcp-server-kubernetes']
-}
-p.write_text(json.dumps(config, indent=2) + '\n')
-"
+uv run python .agents/skills/resources/add-kube-mcp.py
 ```
 
 ---

--- a/tests/test_skill_scripts.py
+++ b/tests/test_skill_scripts.py
@@ -39,6 +39,7 @@ class TestAddKubeMcp:
         assert config["mcpServers"]["kubernetes"] == {
             "command": "npx",
             "args": ["-y", "mcp-server-kubernetes"],
+            "env": {"KUBECONFIG": "~/.kube/my_app.yaml"},
         }
 
     def test_idempotent_when_already_configured(self, project_with_deps: Path) -> None:

--- a/tests/test_skill_scripts.py
+++ b/tests/test_skill_scripts.py
@@ -39,7 +39,7 @@ class TestAddKubeMcp:
         assert config["mcpServers"]["kubernetes"] == {
             "command": "npx",
             "args": ["-y", "mcp-server-kubernetes"],
-            "env": {"KUBECONFIG": "~/.kube/my_app.yaml"},
+            "env": {"KUBECONFIG": "~/.kube/test_project.yaml"},
         }
 
     def test_idempotent_when_already_configured(self, project_with_deps: Path) -> None:


### PR DESCRIPTION
## Summary\n\n- The `add-kube-mcp.py` script now reads `project_slug` from `.copier-answers.yml` and sets `KUBECONFIG` to `~/.kube/<project_slug>.yaml` in the kubernetes MCP server entry\n- Updated `docs/mcp.md` to document the KUBECONFIG env var and simplified the manual add instructions to use the script\n\nCloses #284\n\nCo-Authored-By: Claude <noreply@anthropic.com>