### PR TITLE
fix(dj-launch): Ask webapp replica count before provisioning

### DIFF
--- a/template/.agents/skills/dj-launch/SKILL.md
+++ b/template/.agents/skills/dj-launch/SKILL.md
@@ -52,6 +52,22 @@ If `terraform/hetzner/terraform.tfvars` does not yet exist, tell the user:
 
 ---
 
+## Webapp replica count
+
+Before provisioning infrastructure, ask the user:
+
+> How many webapp instances do you want? (default: 2)
+
+Accept a positive integer. If the user presses Enter or says "default", use **2**.
+
+Save the answer as `<webapp_count>`. This value is used in two places:
+- `webapp_count` in `terraform/hetzner/terraform.tfvars` (number of Hetzner nodes)
+- `replicas` in `helm/site/values.secret.yaml` (number of Kubernetes pods)
+
+Both must match so the cluster has enough nodes to schedule the requested replicas.
+
+---
+
 ## Pre-flight checks
 
 Run all of the following before proceeding. If any fail, tell the user what to install
@@ -121,10 +137,15 @@ If `location` is not already set, ask:
 
 Set `location`.
 
-### 1e. Write terraform.tfvars and apply
+### 1e. Webapp count
 
-Write `terraform/hetzner/terraform.tfvars` with all collected values, preserving any
-existing values that were already set.
+Set `webapp_count` to `<webapp_count>` (collected earlier). This determines how many
+Hetzner nodes are created for webapp pods.
+
+### 1f. Write terraform.tfvars and apply
+
+Write `terraform/hetzner/terraform.tfvars` with all collected values (including
+`webapp_count`), preserving any existing values that were already set.
 
 Then:
 ```bash
@@ -378,6 +399,12 @@ secrets:
 ```
 
 Tell the user these have been generated automatically.
+
+### Webapp replicas
+
+Set `replicas` to `<webapp_count>` (collected at the start of the wizard). This must
+match the `webapp_count` in `terraform/hetzner/terraform.tfvars` so each replica has
+a dedicated node.
 
 ### Values from Terraform outputs
 
@@ -662,7 +689,8 @@ non-secret or required for the user to take action:
 
 | Value | Step | Why the user needs it |
 |-------|------|----------------------|
-| Server IP address | 1e | SSH access, DNS verification |
+| Webapp replica count | Pre-flight | Confirms node and replica count |
+| Server IP address | 1f | SSH access, DNS verification |
 | Domain (confirmed) | 2c | Sanity check |
 | Admin URL path | 4 | Needed to bookmark Django admin |
 | Site URL (`https://<domain>`) | 6c | Confirm app is live |

--- a/template/.agents/skills/dj-launch/SKILL.md
+++ b/template/.agents/skills/dj-launch/SKILL.md
@@ -676,6 +676,7 @@ If **n**, skip silently.
 Tell the user:
 
 > **Next steps (optional):**
+> - Run `/dj-scale [n]` to view or change the webapp replica count
 > - Run `/dj-launch-observability` to deploy Grafana + Prometheus + Loki
 > - Run `/dj-enable-db-backups` to set up automated daily PostgreSQL backups
 > - Run `/dj-rotate-secrets` to rotate auto-generated secrets when ready

--- a/template/helm/site/values.secret.yaml.example.jinja
+++ b/template/helm/site/values.secret.yaml.example.jinja
@@ -5,8 +5,8 @@
 postgres:
   volumePath: "CHANGE_ME"
 
-# Number of webapp replicas
-replicas: 1
+# Number of webapp replicas (must match webapp_count in terraform/hetzner/terraform.tfvars)
+replicas: 2
 
 # Public domain name
 domain: "{{ domain }}"

--- a/template/helm/site/values.yaml.jinja
+++ b/template/helm/site/values.yaml.jinja
@@ -2,7 +2,7 @@
 image: ghcr.io/CHANGE_ME/{{ project_slug }}:main
 
 # Number of webapp replicas - override in values.secret.yaml
-replicas: 1
+replicas: 2
 
 # PostgreSQL configuration
 postgres:


### PR DESCRIPTION
## Summary

- Add a "How many webapp instances do you want?" prompt early in the `/dj-launch` wizard (before the Hetzner terraform step)
- Use the answer for both `webapp_count` in `terraform/hetzner/terraform.tfvars` and `replicas` in `helm/site/values.secret.yaml`
- Change default `replicas` from 1 to 2 in `values.yaml.jinja` and `values.secret.yaml.example.jinja` to match the existing `webapp_count` default

Closes #283

## Test plan

- [x] `just check` passes (115 tests, pre-commit, typecheck all green)
- [ ] Run `/dj-launch` and verify the replica count prompt appears before Step 1
- [ ] Verify `webapp_count` and `replicas` are set to the chosen value

Co-Authored-By: Claude <noreply@anthropic.com>