### PR TITLE
fix: Add one-sub-step-at-a-time warning to all multi-step skills

### DIFF
--- a/template/.agents/skills/dj-create-command/SKILL.md
+++ b/template/.agents/skills/dj-create-command/SKILL.md
@@ -5,6 +5,8 @@ description: Add a management command with tests
 Create a Django management command for the given app, with tests. Optionally
 enqueues background tasks via `django-tasks-db` for long-running or parallel work.
 
+**IMPORTANT: Execute one sub-step at a time. Wait for user confirmation before proceeding to the next sub-step. Do not batch multiple questions or actions into a single response.**
+
 ## Required reading
 
 - `docs/python-style-guide.md`

--- a/template/.agents/skills/dj-create-cron/SKILL.md
+++ b/template/.agents/skills/dj-create-cron/SKILL.md
@@ -4,6 +4,8 @@ description: Schedule a management command as a Kubernetes cron job
 
 Schedule a Django management command as a Kubernetes cron job in `helm/site/values.yaml`.
 
+**IMPORTANT: Execute one sub-step at a time. Wait for user confirmation before proceeding to the next sub-step. Do not batch multiple questions or actions into a single response.**
+
 ## Required reading
 
 - `docs/cron-jobs.md`

--- a/template/.agents/skills/dj-create-crud/SKILL.md
+++ b/template/.agents/skills/dj-create-crud/SKILL.md
@@ -4,6 +4,8 @@ description: Generate full CRUD views, templates, URLs, and tests for a model
 
 Generate a complete set of CRUD views for a model.
 
+**IMPORTANT: Execute one sub-step at a time. Wait for user confirmation before proceeding to the next sub-step. Do not batch multiple questions or actions into a single response.**
+
 ## Required reading
 
 - `docs/python-style-guide.md`

--- a/template/.agents/skills/dj-create-migration/SKILL.md
+++ b/template/.agents/skills/dj-create-migration/SKILL.md
@@ -4,6 +4,8 @@ description: Create an empty Django data migration (Python or SQL) for an app
 
 Create a Django data migration for `<app>`.
 
+**IMPORTANT: Execute one sub-step at a time. Wait for user confirmation before proceeding to the next sub-step. Do not batch multiple questions or actions into a single response.**
+
 ## Required reading
 
 - `docs/python-style-guide.md`

--- a/template/.agents/skills/dj-create-model/SKILL.md
+++ b/template/.agents/skills/dj-create-model/SKILL.md
@@ -4,6 +4,8 @@ description: Design and write a Django model with factory, fixture, and model te
 
 Design and write a Django model with factory, fixture, and model tests.
 
+**IMPORTANT: Execute one sub-step at a time. Wait for user confirmation before proceeding to the next sub-step. Do not batch multiple questions or actions into a single response.**
+
 ## Required reading
 
 - `docs/python-style-guide.md`

--- a/template/.agents/skills/dj-enable-db-backups/SKILL.md
+++ b/template/.agents/skills/dj-enable-db-backups/SKILL.md
@@ -5,6 +5,8 @@ description: Enable automated daily PostgreSQL backups to a private Object Stora
 Interactive wizard to enable automated daily PostgreSQL backups to a private Hetzner
 Object Storage bucket.
 
+**IMPORTANT: Execute one sub-step at a time. Wait for user confirmation before proceeding to the next sub-step. Do not batch multiple questions or actions into a single response.**
+
 ## Required reading
 
 - `docs/deployment.md`

--- a/template/.agents/skills/dj-full-coverage/SKILL.md
+++ b/template/.agents/skills/dj-full-coverage/SKILL.md
@@ -5,6 +5,8 @@ description: Enable 100% coverage gate and write tests for all uncovered lines
 Enforce 100% test coverage by enabling the coverage gate and writing tests
 for every uncovered line.
 
+**IMPORTANT: Execute one sub-step at a time. Wait for user confirmation before proceeding to the next sub-step. Do not batch multiple questions or actions into a single response.**
+
 ---
 
 ## Warning

--- a/template/.agents/skills/dj-launch-observability/SKILL.md
+++ b/template/.agents/skills/dj-launch-observability/SKILL.md
@@ -6,6 +6,8 @@ Deploy the observability stack (Grafana + Prometheus + Loki) to a running cluste
 
 Run this after `/dj-launch` once your application is live.
 
+**IMPORTANT: Execute one sub-step at a time. Wait for user confirmation before proceeding to the next sub-step. Do not batch multiple questions or actions into a single response.**
+
 **Secret handling rules:**
 - Never echo or print secret values to the terminal or chat.
 - When a secret field is empty or `CHANGE_ME`, fill it in the values file directly.

--- a/template/.agents/skills/dj-launch/SKILL.md
+++ b/template/.agents/skills/dj-launch/SKILL.md
@@ -5,6 +5,8 @@ description: Interactive first-deploy wizard: provisions infra, configures secre
 Interactive first-deploy wizard. Guides the user through provisioning infrastructure,
 configuring secrets, and deploying the application end-to-end.
 
+**IMPORTANT: Execute one sub-step at a time. Wait for user confirmation before proceeding to the next sub-step. Do not batch multiple questions or actions into a single response.**
+
 ## Required reading
 
 - `docs/infrastructure.md`

--- a/template/.agents/skills/dj-rotate-secrets/SKILL.md
+++ b/template/.agents/skills/dj-rotate-secrets/SKILL.md
@@ -4,6 +4,8 @@ description: Rotate auto-generated and third-party Helm secrets and redeploy
 
 Rotate secrets in `helm/site/values.secret.yaml` and redeploy.
 
+**IMPORTANT: Execute one sub-step at a time. Wait for user confirmation before proceeding to the next sub-step. Do not batch multiple questions or actions into a single response.**
+
 ## Required reading
 
 - `docs/deployment.md`

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -127,6 +127,7 @@ If a doc contradicts what you see in existing code, flag it — do not silently 
 
 - **Search before implementing** — search with `rg` or `ast-grep` for existing utilities. Check `{{ package_name }}/db/search.py`, `{{ package_name }}/http/`, `{{ package_name }}/partials.py`, and `{{ package_name }}/paginator.py` before writing new code.
 - **Scope discipline** — only change what was explicitly requested.
+- **One step at a time** — in multi-step skills, execute one sub-step at a time. Wait for user confirmation before proceeding to the next. Do not batch multiple questions or actions into a single response.
 - **Diagnose before changing** — state your diagnosis with a file:line reference before editing.
 - **Add imports and first usage in the same edit** — the pre-commit ruff hook strips unused imports immediately. Always add an import and its first usage together in a single edit.
 


### PR DESCRIPTION
## Summary

- Add bold warning to all 10 multi-step skills: dj-launch, dj-create-model, dj-create-command, dj-create-cron, dj-create-migration, dj-create-crud, dj-enable-db-backups, dj-launch-observability, dj-full-coverage, dj-rotate-secrets
- Add general "one step at a time" rule to AGENTS.md.jinja conventions

Supersedes #286 (which only added it to dj-launch).

Closes #275

Co-Authored-By: Claude <noreply@anthropic.com>