### PR TITLE
feat(dj-db-restore): add guided database restore skill and composable production recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Generated projects include `dj-*` Claude Code and OpenCode slash commands for co
 | `/dj-scale [n]`            | View or change the webapp replica count                                        |
 | `/dj-rotate-secrets`       | Rotate auto-generated and third-party Helm secrets and redeploy                |
 | `/dj-enable-db-backups`    | Enable automated daily PostgreSQL backups to a private Object Storage bucket   |
+| `/dj-db-restore`           | Guided production database restore from Object Storage backup                  |
 
 ## MCP Servers
 

--- a/template/.agents/skills/dj-db-restore/SKILL.md
+++ b/template/.agents/skills/dj-db-restore/SKILL.md
@@ -1,0 +1,162 @@
+---
+description: Restore the production database from a Hetzner Object Storage backup
+---
+
+Restore the production database from a backup stored in Hetzner Object Storage.
+
+**IMPORTANT: Execute one sub-step at a time. Wait for user confirmation before proceeding to the next sub-step. Do not batch multiple questions or actions into a single response.**
+
+## Required reading
+
+- `docs/database-backups.md`
+- `docs/cron-jobs.md`
+
+---
+
+## Step 1 — Check backups are configured
+
+Check whether backup credentials exist in the cluster:
+
+```bash
+just kube get secret backup-secret --ignore-not-found -o name
+```
+
+If the output is empty, tell the user:
+
+> Backups are not configured on this cluster. Run `/dj-enable-db-backups` to set up
+> automated backups before attempting a restore.
+
+Stop.
+
+---
+
+## Step 2 — List available backups
+
+Run a one-off pod to list backups from Object Storage:
+
+```bash
+just kube run --rm -it list-backups \
+  --image=amazon/aws-cli:2 \
+  --restart=Never \
+  --env="AWS_ACCESS_KEY_ID=$(just kube get secret backup-secret -o jsonpath='{.data.BACKUP_ACCESS_KEY}' | base64 -d)" \
+  --env="AWS_SECRET_ACCESS_KEY=$(just kube get secret backup-secret -o jsonpath='{.data.BACKUP_SECRET_KEY}' | base64 -d)" \
+  --env="AWS_DEFAULT_REGION=$(just kube get secret backup-secret -o jsonpath='{.data.BACKUP_REGION}' | base64 -d)" \
+  --env="BACKUP_ENDPOINT=$(just kube get secret backup-secret -o jsonpath='{.data.BACKUP_ENDPOINT}' | base64 -d)" \
+  --env="BACKUP_BUCKET=$(just kube get secret backup-secret -o jsonpath='{.data.BACKUP_BUCKET}' | base64 -d)" \
+  -- sh -c 'aws --endpoint-url "$BACKUP_ENDPOINT" s3 ls s3://$BACKUP_BUCKET/ | sort'
+```
+
+If the output is empty, tell the user no backups are available yet and stop.
+
+Ask if they want to filter by date. Then present the list and ask the user to select a
+backup (default: most recent):
+
+> Available backups:
+> 1. backup-20260325-030000.sql.gz  (2026-03-25 03:00)
+> 2. backup-20260326-030000.sql.gz  (2026-03-26 03:00)
+> 3. **backup-20260327-030000.sql.gz  (2026-03-27 03:00) [default]**
+>
+> Which backup would you like to restore? [3]
+
+Wait for the user to confirm their selection.
+
+---
+
+## Step 3 — Confirm restore
+
+Warn the user clearly before proceeding:
+
+> ⚠️ This will restore the database to `<selected-filename>`.
+> The current database will be overwritten. A safety backup will be taken first.
+> Are you sure? [y/n]
+
+If no, stop.
+
+---
+
+## Step 4 — Disable CronJobs
+
+Suspend all CronJobs to prevent scheduled tasks from firing during the restore:
+
+```bash
+just rcrons-disable
+```
+
+---
+
+## Step 5 — Take a safety backup
+
+Trigger an immediate backup before overwriting the database:
+
+```bash
+just kube create job postgres-backup-pre-restore --from=cronjob/postgres-backup
+```
+
+Wait for it to complete (timeout: 5 minutes):
+
+```bash
+just kube wait --for=condition=complete job/postgres-backup-pre-restore --timeout=300s
+```
+
+If the job fails or times out, tell the user:
+
+> Safety backup failed. The restore has been paused. Re-enable CronJobs with:
+>
+> ```bash
+> just rcrons-enable
+> ```
+>
+> Then check the backup job logs:
+>
+> ```bash
+> just kube logs job/postgres-backup-pre-restore --all-containers
+> ```
+
+Stop without proceeding to the restore.
+
+Clean up the job after success:
+
+```bash
+just kube delete job postgres-backup-pre-restore
+```
+
+---
+
+## Step 6 — Restore the backup
+
+```bash
+just rdb-restore <selected-filename>
+```
+
+Confirm the prompt when asked. The script scales down the app and worker, runs the
+in-cluster restore pod, then scales them back up to their original replica counts.
+
+---
+
+## Step 7 — Verify
+
+Run migrations to confirm the restored database is consistent:
+
+```bash
+just rdj migrate
+```
+
+If migrations fail, stop and tell the user to check the backup file and restore logs
+before proceeding.
+
+---
+
+## Step 8 — Re-enable CronJobs
+
+```bash
+just rcrons-enable
+```
+
+---
+
+## Step 9 — Done
+
+Tell the user:
+
+> Database restored from `<selected-filename>`. Migrations applied and CronJobs resumed.
+> Open the site to confirm everything is working as expected.

--- a/template/.agents/skills/dj-db-restore/resources/help.md
+++ b/template/.agents/skills/dj-db-restore/resources/help.md
@@ -1,0 +1,36 @@
+**/dj-db-restore**
+
+Guided production database restore from a Hetzner Object Storage backup.
+
+**Usage**
+
+```
+/dj-db-restore
+```
+
+No arguments — the skill walks you through every step interactively.
+
+**What it does**
+
+1. Checks that backup credentials are configured in the cluster (`backup-secret`).
+2. Lists available backups from Object Storage and asks you to select one (default: most recent). Offers date filtering.
+3. Asks for confirmation before overwriting the database.
+4. Suspends all CronJobs (`just rcrons-disable`).
+5. Takes a safety backup of the current database before proceeding.
+6. Runs `just rdb-restore <filename>` — scales down app and worker, restores in-cluster, scales back up.
+7. Runs `just rdj migrate` to verify the restored database is consistent.
+8. Resumes all CronJobs (`just rcrons-enable`).
+
+**Prerequisites**
+
+- Cluster access configured (`KUBECONFIG` set or `~/.kube/<project>.yaml` present)
+- Backups enabled (`backup.enabled: true` in `helm/site/values.secret.yaml` and deployed)
+
+**Related commands**
+
+- `/dj-enable-db-backups` — set up automated backups if not yet configured
+- `just rdb-backup` — trigger a manual backup immediately
+- `just rcrons-disable [name]` — suspend all or one CronJob
+- `just rcrons-enable [name]` — resume all or one CronJob
+
+**See also:** `docs/database-backups.md`

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -191,6 +191,7 @@ Available in Claude Code and OpenCode as `/dj-<command>`.
 | `/dj-scale [n]` | View or change the webapp replica count |
 | `/dj-rotate-secrets` | Rotate auto-generated and third-party Helm secrets and redeploy |
 | `/dj-enable-db-backups` | Enable automated daily PostgreSQL backups to Object Storage |
+| `/dj-db-restore`        | Guided production database restore from Object Storage backup |
 
 
 ## MCP Servers

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -104,6 +104,7 @@ Available in Claude Code and OpenCode as `/dj-<command>`:
 | `/dj-scale [n]`            | View or change the webapp replica count                                        |
 | `/dj-rotate-secrets`       | Rotate auto-generated and third-party Helm secrets and redeploy                |
 | `/dj-enable-db-backups`    | Enable automated daily PostgreSQL backups to a private Object Storage bucket   |
+| `/dj-db-restore`           | Guided production database restore from Object Storage backup                  |
 
 ## MCP Servers
 

--- a/template/docs/cron-jobs.md
+++ b/template/docs/cron-jobs.md
@@ -13,6 +13,7 @@ and creates one `CronJob` per entry.
 - [Resource Limits](#resource-limits)
 - [Concurrency Policy](#concurrency-policy)
 - [Node Scheduling](#node-scheduling)
+- [Suspending and Resuming CronJobs](#suspending-and-resuming-cronjobs)
 - [Observing Jobs](#observing-jobs)
 
 ## Adding a Cron Job
@@ -127,6 +128,26 @@ nodeSelector:
 This is already set in all chart templates (`cronjobs.yaml`, `postgres-backup-cronjob.yaml`,
 `release-job.yaml`) and in the `db-restore` pod created by `just rdb-restore`. When adding
 any new one-off job or CronJob, always include this selector.
+
+## Suspending and Resuming CronJobs
+
+During maintenance windows (e.g. database restores), suspend CronJobs to prevent
+scheduled tasks from firing while the cluster is in a degraded state:
+
+```bash
+just rcrons-disable                    # suspend all CronJobs
+just rcrons-disable postgres-backup    # suspend one specific CronJob
+```
+
+Re-enable them once maintenance is complete:
+
+```bash
+just rcrons-enable                     # resume all CronJobs
+just rcrons-enable postgres-backup     # resume one specific CronJob
+```
+
+These commands patch the CronJob's `spec.suspend` field. Any jobs that were already
+running when you suspend are not interrupted — only future scheduled runs are blocked.
 
 ## Observing Jobs
 

--- a/template/docs/database-backups.md
+++ b/template/docs/database-backups.md
@@ -174,7 +174,15 @@ Output looks like this (newest last):
 
 Pick the filename you want to restore. In most cases this is the most recent one (last line).
 
-### Step 2 — Run the restore
+### Step 2 — Disable CronJobs
+
+Suspend scheduled tasks before taking the cluster down:
+
+```bash
+just rcrons-disable
+```
+
+### Step 3 — Run the restore
 
 ```bash
 just rdb-restore backup-20240103-030000.sql.gz
@@ -186,12 +194,18 @@ Confirm the prompt. The script will:
 2. Start a temporary in-cluster pod that downloads the backup from Object Storage
 3. Drop and restore the `postgres` database inside the pod
 4. Delete the pod
-5. Scale `django-app` and `django-worker` back up
+5. Scale `django-app` and `django-worker` back up to their previous replica counts
 
 You will see progress logs for each phase streamed to your terminal. The whole
 process takes 2–10 minutes depending on database size.
 
-### Step 3 — Run migrations and confirm the site is live
+### Step 4 — Re-enable CronJobs
+
+```bash
+just rcrons-enable
+```
+
+### Step 5 — Run migrations and confirm the site is live
 
 ```bash
 just rdj migrate
@@ -228,12 +242,12 @@ gunzip /tmp/$BACKUP_FILE
 SQL_FILE="/tmp/backup-20240103-030000.sql"
 ```
 
-**Step C — Scale down the app**
+**Step C — Disable CronJobs and scale down the app**
 
 ```bash
-just kube scale deployment/django-app --replicas=0
-just kube scale deployment/django-worker --replicas=0
-just kube get pods   # wait until app/worker pods are gone
+just rcrons-disable
+just rscale-down django-app
+just rscale-down django-worker
 ```
 
 **Step D — Port-forward postgres and restore**
@@ -250,11 +264,12 @@ psql -h localhost -p 5432 -U postgres -d postgres < $SQL_FILE
 kill $PF_PID
 ```
 
-**Step E — Verify and scale up**
+**Step E — Scale up, re-enable CronJobs, and verify**
 
 ```bash
-just kube scale deployment/django-app --replicas=1
-just kube scale deployment/django-worker --replicas=1
+just rscale-up django-app 1
+just rscale-up django-worker 1
+just rcrons-enable
 just rdj migrate
 rm $SQL_FILE
 ```

--- a/template/just/db_restore.sh.jinja
+++ b/template/just/db_restore.sh.jinja
@@ -13,11 +13,13 @@ FILENAME="${1:?Usage: db_restore.sh <backup-filename.sql.gz>}"
 # Read the postgres image from the running StatefulSet so the restore version matches exactly.
 POSTGRES_IMAGE=$(kubectl get statefulset postgres -o jsonpath='{.spec.template.spec.containers[0].image}')
 
-echo "==> Scaling down app and worker..."
-kubectl scale deployment/django-app --replicas=0
-kubectl scale deployment/django-worker --replicas=0
-kubectl wait --for=delete pod -l app=django-app --timeout=60s 2>/dev/null || true
-kubectl wait --for=delete pod -l app=django-worker --timeout=60s 2>/dev/null || true
+# Capture current replica counts so we restore to the same number after the restore.
+APP_REPLICAS=$(kubectl get deployment/django-app -o jsonpath='{.spec.replicas}' 2>/dev/null || echo 1)
+WORKER_REPLICAS=$(kubectl get deployment/django-worker -o jsonpath='{.spec.replicas}' 2>/dev/null || echo 1)
+
+echo "==> Scaling down app (${APP_REPLICAS} replicas) and worker (${WORKER_REPLICAS} replicas)..."
+just rscale-down django-app
+just rscale-down django-worker
 
 echo "==> Starting in-cluster restore pod for: ${FILENAME}"
 kubectl delete pod db-restore --ignore-not-found=true
@@ -103,9 +105,9 @@ kubectl logs pod/db-restore -c restore
 
 kubectl delete pod db-restore
 
-echo "==> Scaling app back up..."
-kubectl scale deployment/django-app --replicas=1
-kubectl scale deployment/django-worker --replicas=1
+echo "==> Scaling app back up to ${APP_REPLICAS} replicas..."
+just rscale-up django-app "${APP_REPLICAS}"
+just rscale-up django-worker "${WORKER_REPLICAS}"
 
 echo ""
 echo "Done. Run: just rdj migrate"

--- a/template/justfile
+++ b/template/justfile
@@ -235,8 +235,53 @@ rdb-backup:
 
 # Restore production database from a named backup file - runs entirely in-cluster, no local tools needed
 # Usage: just rdb-restore backup-20240103-030000.sql.gz
-# See docs/Backups.md for the full restore guide including how to list available backups.
+# See docs/database-backups.md for the full restore guide including how to list available backups.
 [group('production')]
 [confirm("WARNING!!! Are you sure you want to run this command on production? (y/N)")]
 rdb-restore filename:
     {{ script_dir }}/db_restore.sh {{ filename }}
+
+# Scale a production deployment to 0 replicas and wait for pods to terminate
+# Usage: just rscale-down <service>  e.g. just rscale-down django-app
+[group('production')]
+rscale-down service:
+    kubectl --kubeconfig {{ kubeconfig }} scale deployment/{{ service }} --replicas=0
+    kubectl --kubeconfig {{ kubeconfig }} wait --for=delete pod -l app={{ service }} --timeout=60s 2>/dev/null || true
+
+# Scale a production deployment to a given replica count
+# Usage: just rscale-up <service> <count>  e.g. just rscale-up django-app 2
+[group('production')]
+rscale-up service count:
+    kubectl --kubeconfig {{ kubeconfig }} scale deployment/{{ service }} --replicas={{ count }}
+
+# Suspend CronJobs on the production cluster. Suspends all if no name given.
+# Usage: just rcrons-disable [name]  e.g. just rcrons-disable postgres-backup
+[group('production')]
+rcrons-disable name="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export KUBECONFIG="{{ kubeconfig }}"
+    if [[ -n "{{ name }}" ]]; then
+        kubectl patch cronjob/{{ name }} -p '{"spec":{"suspend":true}}'
+    else
+        while IFS= read -r cj; do
+            kubectl patch "$cj" -p '{"spec":{"suspend":true}}'
+        done < <(kubectl get cronjobs -o name 2>/dev/null)
+        echo "All CronJobs suspended."
+    fi
+
+# Resume CronJobs on the production cluster. Resumes all if no name given.
+# Usage: just rcrons-enable [name]  e.g. just rcrons-enable postgres-backup
+[group('production')]
+rcrons-enable name="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    export KUBECONFIG="{{ kubeconfig }}"
+    if [[ -n "{{ name }}" ]]; then
+        kubectl patch cronjob/{{ name }} -p '{"spec":{"suspend":false}}'
+    else
+        while IFS= read -r cj; do
+            kubectl patch "$cj" -p '{"spec":{"suspend":false}}'
+        done < <(kubectl get cronjobs -o name 2>/dev/null)
+        echo "All CronJobs resumed."
+    fi


### PR DESCRIPTION
Add the `/dj-db-restore` skill and four new composable `just` recipes for production maintenance.

## New `just` recipes

- `just rscale-down <service>` — scale a deployment to 0 and wait for pods to terminate
- `just rscale-up <service> <count>` — scale a deployment to an explicit replica count
- `just rcrons-disable [name]` — suspend all CronJobs, or one by name
- `just rcrons-enable [name]` — resume all CronJobs, or one by name

These follow the existing `r`-prefix convention for production commands and are designed to be composed by scripts and skills rather than duplicating kubectl incantations in multiple places.

## `db_restore.sh` fix

The restore script previously hardcoded `--replicas=1` on scale-up. It now captures the current replica count for both `django-app` and `django-worker` before scaling down, and restores to those counts after the restore completes. The inline `kubectl scale` calls are replaced with `just rscale-down`/`just rscale-up`.

## `/dj-db-restore` skill

Guided restore workflow:

1. Checks `backup-secret` exists in the cluster (exits early if backups not configured)
2. Lists available backups from Object Storage; offers date filtering; defaults to most recent
3. Confirms before overwriting the database
4. `just rcrons-disable` — prevents cron jobs firing mid-restore
5. Triggers a safety backup job and waits for completion before proceeding
6. `just rdb-restore <filename>` — handles scale-down, in-cluster restore, scale-up
7. `just rdj migrate` — verifies the restored database is consistent
8. `just rcrons-enable` — resumes scheduled jobs

## Docs

- `docs/cron-jobs.md` — new "Suspending and Resuming CronJobs" section
- `docs/database-backups.md` — manual restore steps updated to use `rcrons-disable`/`rcrons-enable` and `rscale-down`/`rscale-up`

Closes #298