### PR TITLE
refactor(justfile): rename kube→rkube and gate all production commands with [confirm]

### DIFF
--- a/template/.agents/skills/dj-db-restore/SKILL.md
+++ b/template/.agents/skills/dj-db-restore/SKILL.md
@@ -18,7 +18,7 @@ Restore the production database from a backup stored in Hetzner Object Storage.
 Check whether backup credentials exist in the cluster:
 
 ```bash
-just kube get secret backup-secret --ignore-not-found -o name
+just --yes rkube get secret backup-secret --ignore-not-found -o name
 ```
 
 If the output is empty, tell the user:
@@ -35,14 +35,14 @@ Stop.
 Run a one-off pod to list backups from Object Storage:
 
 ```bash
-just kube run --rm -it list-backups \
+just --yes rkube run --rm -it list-backups \
   --image=amazon/aws-cli:2 \
   --restart=Never \
-  --env="AWS_ACCESS_KEY_ID=$(just kube get secret backup-secret -o jsonpath='{.data.BACKUP_ACCESS_KEY}' | base64 -d)" \
-  --env="AWS_SECRET_ACCESS_KEY=$(just kube get secret backup-secret -o jsonpath='{.data.BACKUP_SECRET_KEY}' | base64 -d)" \
-  --env="AWS_DEFAULT_REGION=$(just kube get secret backup-secret -o jsonpath='{.data.BACKUP_REGION}' | base64 -d)" \
-  --env="BACKUP_ENDPOINT=$(just kube get secret backup-secret -o jsonpath='{.data.BACKUP_ENDPOINT}' | base64 -d)" \
-  --env="BACKUP_BUCKET=$(just kube get secret backup-secret -o jsonpath='{.data.BACKUP_BUCKET}' | base64 -d)" \
+  --env="AWS_ACCESS_KEY_ID=$(just --yes rkube get secret backup-secret -o jsonpath='{.data.BACKUP_ACCESS_KEY}' | base64 -d)" \
+  --env="AWS_SECRET_ACCESS_KEY=$(just --yes rkube get secret backup-secret -o jsonpath='{.data.BACKUP_SECRET_KEY}' | base64 -d)" \
+  --env="AWS_DEFAULT_REGION=$(just --yes rkube get secret backup-secret -o jsonpath='{.data.BACKUP_REGION}' | base64 -d)" \
+  --env="BACKUP_ENDPOINT=$(just --yes rkube get secret backup-secret -o jsonpath='{.data.BACKUP_ENDPOINT}' | base64 -d)" \
+  --env="BACKUP_BUCKET=$(just --yes rkube get secret backup-secret -o jsonpath='{.data.BACKUP_BUCKET}' | base64 -d)" \
   -- sh -c 'aws --endpoint-url "$BACKUP_ENDPOINT" s3 ls s3://$BACKUP_BUCKET/ | sort'
 ```
 
@@ -79,7 +79,7 @@ If no, stop.
 Suspend all CronJobs to prevent scheduled tasks from firing during the restore:
 
 ```bash
-just rcrons-disable
+just --yes rcrons-disable
 ```
 
 ---
@@ -89,13 +89,13 @@ just rcrons-disable
 Trigger an immediate backup before overwriting the database:
 
 ```bash
-just kube create job postgres-backup-pre-restore --from=cronjob/postgres-backup
+just --yes rkube create job postgres-backup-pre-restore --from=cronjob/postgres-backup
 ```
 
 Wait for it to complete (timeout: 5 minutes):
 
 ```bash
-just kube wait --for=condition=complete job/postgres-backup-pre-restore --timeout=300s
+just --yes rkube wait --for=condition=complete job/postgres-backup-pre-restore --timeout=300s
 ```
 
 If the job fails or times out, tell the user:
@@ -103,13 +103,13 @@ If the job fails or times out, tell the user:
 > Safety backup failed. The restore has been paused. Re-enable CronJobs with:
 >
 > ```bash
-> just rcrons-enable
+> just --yes rcrons-enable
 > ```
 >
 > Then check the backup job logs:
 >
 > ```bash
-> just kube logs job/postgres-backup-pre-restore --all-containers
+> just --yes rkube logs job/postgres-backup-pre-restore --all-containers
 > ```
 
 Stop without proceeding to the restore.
@@ -117,7 +117,7 @@ Stop without proceeding to the restore.
 Clean up the job after success:
 
 ```bash
-just kube delete job postgres-backup-pre-restore
+just --yes rkube delete job postgres-backup-pre-restore
 ```
 
 ---
@@ -125,7 +125,7 @@ just kube delete job postgres-backup-pre-restore
 ## Step 6 — Restore the backup
 
 ```bash
-just rdb-restore <selected-filename>
+just --yes rdb-restore <selected-filename>
 ```
 
 Confirm the prompt when asked. The script scales down the app and worker, runs the
@@ -138,7 +138,7 @@ in-cluster restore pod, then scales them back up to their original replica count
 Run migrations to confirm the restored database is consistent:
 
 ```bash
-just rdj migrate
+just --yes rdj migrate
 ```
 
 If migrations fail, stop and tell the user to check the backup file and restore logs
@@ -149,7 +149,7 @@ before proceeding.
 ## Step 8 — Re-enable CronJobs
 
 ```bash
-just rcrons-enable
+just --yes rcrons-enable
 ```
 
 ---

--- a/template/.agents/skills/dj-db-restore/SKILL.md
+++ b/template/.agents/skills/dj-db-restore/SKILL.md
@@ -103,13 +103,13 @@ If the job fails or times out, tell the user:
 > Safety backup failed. The restore has been paused. Re-enable CronJobs with:
 >
 > ```bash
-> just --yes rcrons-enable
+> just rcrons-enable
 > ```
 >
 > Then check the backup job logs:
 >
 > ```bash
-> just --yes rkube logs job/postgres-backup-pre-restore --all-containers
+> just rkube logs job/postgres-backup-pre-restore --all-containers
 > ```
 
 Stop without proceeding to the restore.

--- a/template/.agents/skills/dj-enable-db-backups/SKILL.md
+++ b/template/.agents/skills/dj-enable-db-backups/SKILL.md
@@ -23,7 +23,7 @@ are already set. Re-running is safe.
 Verify the cluster is accessible and Terraform is installed:
 
 ```bash
-just kube get pods    # cluster must be reachable
+just --yes rkube get pods    # cluster must be reachable
 terraform version     # Terraform must be installed
 ```
 
@@ -160,9 +160,9 @@ Wait for the command to complete. If it fails, show the error and help the user 
 Verify the CronJob, secret, and scripts ConfigMap were created:
 
 ```bash
-just kube get cronjob postgres-backup
-just kube get secret backup-secret
-just kube get configmap db-scripts
+just --yes rkube get cronjob postgres-backup
+just --yes rkube get secret backup-secret
+just --yes rkube get configmap db-scripts
 ```
 
 ---
@@ -174,20 +174,20 @@ Tell the user:
 > **Testing the first backup now...**
 
 ```bash
-just kube create job postgres-backup-test --from=cronjob/postgres-backup
+just --yes rkube create job postgres-backup-test --from=cronjob/postgres-backup
 ```
 
 Wait for the job to complete (poll every 5 seconds, timeout after 5 minutes):
 
 ```bash
-just kube wait --for=condition=complete job/postgres-backup-test --timeout=300s
+just --yes rkube wait --for=condition=complete job/postgres-backup-test --timeout=300s
 ```
 
 If it times out or fails, show the logs from both containers:
 
 ```bash
-just kube logs job/postgres-backup-test -c dump
-just kube logs job/postgres-backup-test -c upload
+just --yes rkube logs job/postgres-backup-test -c dump
+just --yes rkube logs job/postgres-backup-test -c upload
 ```
 
 Diagnose the failure and help the user fix it before declaring success.
@@ -195,8 +195,8 @@ Diagnose the failure and help the user fix it before declaring success.
 If the job succeeds, show the upload logs and then clean up:
 
 ```bash
-just kube logs job/postgres-backup-test -c upload
-just kube delete job postgres-backup-test
+just --yes rkube logs job/postgres-backup-test -c upload
+just --yes rkube delete job postgres-backup-test
 ```
 
 ---

--- a/template/.agents/skills/dj-launch-observability/SKILL.md
+++ b/template/.agents/skills/dj-launch-observability/SKILL.md
@@ -22,7 +22,7 @@ Check if the Kubernetes MCP server is configured in `.mcp.json`. If
 by listing nodes. Otherwise:
 
 ```bash
-just kube get nodes
+just --yes rkube get nodes
 ```
 
 If this fails, ensure your kubeconfig is set up (`just get-kubeconfig`).
@@ -86,7 +86,7 @@ Then verify pods are running. If Kubernetes MCP is configured, use it to check p
 status in the `monitoring` namespace. Otherwise:
 
 ```bash
-just kube get pods -n monitoring
+just --yes rkube get pods -n monitoring
 ```
 
 Once all pods are Running, tell the user:
@@ -106,7 +106,7 @@ Read `secrets.openTelemetryUrl` from `helm/site/values.secret.yaml`.
 If it is empty, discover the OTLP collector service name dynamically:
 
 ```bash
-just kube get svc -A | grep otel
+just --yes rkube get svc -A | grep otel
 ```
 
 Use the discovered service name and namespace to build the endpoint URL. The
@@ -119,7 +119,7 @@ http://otel-gateway.default.svc.cluster.local:4318
 If no otel service is found, tell the user:
 
 > No OTLP collector service found in the cluster. Verify the observability
-> chart deployed correctly with `just kube get pods -n monitoring`.
+> chart deployed correctly with `just --yes rkube get pods -n monitoring`.
 
 Write the discovered endpoint to `secrets.openTelemetryUrl`.
 

--- a/template/.agents/skills/dj-launch/SKILL.md
+++ b/template/.agents/skills/dj-launch/SKILL.md
@@ -622,19 +622,19 @@ gh run watch
 
 Then show pod status:
 ```bash
-just kube get pods
+just --yes rkube get pods
 ```
 
 If all pods are Running:
 
 If `<site_name>` was provided in Step 4, run:
 ```bash
-just rdj set_default_site <domain> "<site_name>"
+just --yes rdj set_default_site <domain> "<site_name>"
 ```
 
 If it was not provided, tell the user:
 > You can set the default site name at any time by running:
-> `just rdj set_default_site <domain> "Your Site Name"`
+> `just --yes rdj set_default_site <domain> "Your Site Name"`
 
 Then tell the user:
 
@@ -642,13 +642,13 @@ Then tell the user:
 > Your app is live at https://<domain>
 >
 > Next steps:
-> - Run `just rdj createsuperuser` to create an admin account
+> - Run `just --yes rdj createsuperuser` to create an admin account
 > - Visit https://<domain>/<admin-url> to access the Django admin
 
 If any pods are not Running, show the pod status and relevant logs:
 ```bash
-just kube describe pod <failing-pod>
-just kube logs <failing-pod>
+just --yes rkube describe pod <failing-pod>
+just --yes rkube logs <failing-pod>
 ```
 Diagnose and help the user fix the issue before declaring success.
 

--- a/template/.agents/skills/dj-rotate-secrets/SKILL.md
+++ b/template/.agents/skills/dj-rotate-secrets/SKILL.md
@@ -181,7 +181,7 @@ services still expect the old ones, causing immediate 500 errors.
 
 **PostgreSQL:**
 ```bash
-just kube exec postgres-0 -- bash -c "psql -U postgres -c \"ALTER USER postgres PASSWORD '<new_postgres_password>';\""
+just --yes rkube exec postgres-0 -- bash -c "psql -U postgres -c \"ALTER USER postgres PASSWORD '<new_postgres_password>';\""
 ```
 
 **Verify** the output contains `ALTER ROLE`. If it does not (empty output, error, or
@@ -199,7 +199,7 @@ If **manual**, stop and tell the user to re-run `/dj-rotate-secrets` when ready.
 
 **Redis:**
 ```bash
-just kube exec deploy/redis -- redis-cli -a "<old_redis_password>" CONFIG SET requirepass "<new_redis_password>"
+just --yes rkube exec deploy/redis -- redis-cli -a "<old_redis_password>" CONFIG SET requirepass "<new_redis_password>"
 ```
 
 **Verify** the output contains `OK`. If it does not, **stop immediately**. Tell the
@@ -234,7 +234,7 @@ b64_redis_pass=$(printf '%s' "$new_redis" | base64 -w0)
 b64_redis_url=$(printf 'redis://default:%s@redis.%s.svc.cluster.local:6379/0' \
   "$new_redis" "$namespace" | base64 -w0)
 
-just kube patch secret secrets -p "{\"data\":{
+just --yes rkube patch secret secrets -p "{\"data\":{
   \"POSTGRES_PASSWORD\":\"$b64_pg_pass\",
   \"DATABASE_URL\":\"$b64_db_url\",
   \"REDIS_PASSWORD\":\"$b64_redis_pass\",
@@ -254,7 +254,7 @@ Environment variables are baked into pods at start time. Restart the app and
 worker deployments so running pods pick up the patched secret:
 
 ```bash
-just kube rollout restart deployment/django-app deployment/django-worker
+just --yes rkube rollout restart deployment/django-app deployment/django-worker
 ```
 
 **Verify** each deployment shows `deployment.apps/django-app restarted` and

--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -37,8 +37,8 @@ repos:
     rev: v8.30.0
     hooks:
       - id: gitleaks
-  - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.11.0
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -49,6 +49,22 @@ just start / just stop  # Docker services (PostgreSQL, Redis, Mailpit)
 
 Run `just` with no arguments for the full command list.
 
+### Production commands (`r` prefix)
+
+All production commands use the `r` prefix and are gated with an interactive confirmation
+prompt. When running them inside a skill (where the user has already confirmed intent),
+use `just --yes` to suppress the prompt:
+
+```bash
+just --yes rkube get pods          # run kubectl without re-prompting
+just --yes rdj migrate             # run manage.py on production
+just --yes rscale-down django-app  # scale down a deployment
+just --yes rcrons-disable          # suspend all CronJobs
+```
+
+Human-invoked commands (typed directly in the terminal) do not need `--yes` — the
+confirmation is the intended safety gate.
+
 Tests live in `{{ package_name }}/**/tests/`; framework: `pytest`+`pytest-django`; E2E tests marked `@pytest.mark.e2e`.
 
 ## Git Workflow

--- a/template/docs/database-backups.md
+++ b/template/docs/database-backups.md
@@ -99,7 +99,7 @@ just helm site
 Verify the CronJob was created:
 
 ```bash
-just kube get cronjob postgres-backup
+just rkube get cronjob postgres-backup
 ```
 
 ### Step 4 — Trigger a test backup
@@ -107,14 +107,14 @@ just kube get cronjob postgres-backup
 Run a manual job to confirm the first backup works before relying on the schedule:
 
 ```bash
-just kube create job postgres-backup-test --from=cronjob/postgres-backup
+just rkube create job postgres-backup-test --from=cronjob/postgres-backup
 ```
 
 Watch the logs:
 
 ```bash
-just kube logs -f job/postgres-backup-test -c dump
-just kube logs -f job/postgres-backup-test -c upload
+just rkube logs -f job/postgres-backup-test -c dump
+just rkube logs -f job/postgres-backup-test -c upload
 ```
 
 You should see the dump size and "Upload complete". Then verify the file appeared in
@@ -123,7 +123,7 @@ the bucket by following the "List available backups" steps in the Restore sectio
 Clean up the test job:
 
 ```bash
-just kube delete job postgres-backup-test
+just rkube delete job postgres-backup-test
 ```
 
 ## Configuration
@@ -145,7 +145,7 @@ backup:
 
 ### What you need before starting
 
-- Cluster access (`KUBECONFIG` configured — test with `just kube get pods`)
+- Cluster access (`KUBECONFIG` configured — test with `just rkube get pods`)
 - The backup filename you want to restore (Step 1 shows how to find it)
 
 ### Step 1 — List available backups
@@ -153,14 +153,14 @@ backup:
 Run a one-off pod using the `backup-secret` credentials already in your cluster:
 
 ```bash
-just kube run --rm -it list-backups \
+just rkube run --rm -it list-backups \
   --image=amazon/aws-cli:2 \
   --restart=Never \
-  --env="AWS_ACCESS_KEY_ID=$(just kube get secret backup-secret -o jsonpath='{.data.BACKUP_ACCESS_KEY}' | base64 -d)" \
-  --env="AWS_SECRET_ACCESS_KEY=$(just kube get secret backup-secret -o jsonpath='{.data.BACKUP_SECRET_KEY}' | base64 -d)" \
-  --env="AWS_DEFAULT_REGION=$(just kube get secret backup-secret -o jsonpath='{.data.BACKUP_REGION}' | base64 -d)" \
-  --env="BACKUP_ENDPOINT=$(just kube get secret backup-secret -o jsonpath='{.data.BACKUP_ENDPOINT}' | base64 -d)" \
-  --env="BACKUP_BUCKET=$(just kube get secret backup-secret -o jsonpath='{.data.BACKUP_BUCKET}' | base64 -d)" \
+  --env="AWS_ACCESS_KEY_ID=$(just rkube get secret backup-secret -o jsonpath='{.data.BACKUP_ACCESS_KEY}' | base64 -d)" \
+  --env="AWS_SECRET_ACCESS_KEY=$(just rkube get secret backup-secret -o jsonpath='{.data.BACKUP_SECRET_KEY}' | base64 -d)" \
+  --env="AWS_DEFAULT_REGION=$(just rkube get secret backup-secret -o jsonpath='{.data.BACKUP_REGION}' | base64 -d)" \
+  --env="BACKUP_ENDPOINT=$(just rkube get secret backup-secret -o jsonpath='{.data.BACKUP_ENDPOINT}' | base64 -d)" \
+  --env="BACKUP_BUCKET=$(just rkube get secret backup-secret -o jsonpath='{.data.BACKUP_BUCKET}' | base64 -d)" \
   -- sh -c 'aws --endpoint-url "$BACKUP_ENDPOINT" s3 ls s3://$BACKUP_BUCKET/ | sort'
 ```
 
@@ -253,7 +253,7 @@ just rscale-down django-worker
 **Step D — Port-forward postgres and restore**
 
 ```bash
-just kube port-forward service/postgres 5432:5432 &
+just rkube port-forward service/postgres 5432:5432 &
 PF_PID=$!
 sleep 2
 
@@ -281,19 +281,19 @@ rm $SQL_FILE
 ### Backup job fails — dump stage
 
 ```bash
-just kube logs job/<job-name> -c dump
+just rkube logs job/<job-name> -c dump
 ```
 
 Common causes:
 - **`pg_isready` healthy but pg_dump fails** — the postgres pod may be under heavy load.
-  Check `just kube logs statefulset/postgres`.
+  Check `just rkube logs statefulset/postgres`.
 - **Password error** — the `backup-secret` may be out of sync with the postgres password.
   Re-run `just helm site` to re-apply secrets.
 
 ### Backup job fails — upload stage
 
 ```bash
-just kube logs job/<job-name> -c upload
+just rkube logs job/<job-name> -c upload
 ```
 
 Common causes:
@@ -310,7 +310,7 @@ The port-forward may have dropped. Kill it and restart:
 
 ```bash
 kill $PF_PID 2>/dev/null; sleep 1
-just kube port-forward service/postgres 5432:5432 &
+just rkube port-forward service/postgres 5432:5432 &
 PF_PID=$!
 sleep 2
 ```
@@ -320,7 +320,7 @@ sleep 2
 The app pods did not fully terminate. Wait and recheck:
 
 ```bash
-just kube get pods
+just rkube get pods
 ```
 
 If Django pods are still Terminating, wait 30 seconds and try again.

--- a/template/docs/deployment.md
+++ b/template/docs/deployment.md
@@ -226,7 +226,7 @@ This is fine for open-source or personal projects where the image itself contain
 Create a GitHub PAT with `read:packages` scope, then add it to the cluster:
 
 ```bash
-just kube create secret docker-registry ghcr-pull-secret \
+just rkube create secret docker-registry ghcr-pull-secret \
   --docker-server=ghcr.io \
   --docker-username=<github-username> \
   --docker-password=<your-pat>
@@ -264,8 +264,8 @@ just rdj createsuperuser
 just rpsql
 
 # Kubernetes
-just kube get pods
-just kube logs -f deployment/django-app
+just rkube get pods
+just rkube logs -f deployment/django-app
 
 # Fetch kubeconfig
 just get-kubeconfig

--- a/template/just/db_restore.sh.jinja
+++ b/template/just/db_restore.sh.jinja
@@ -18,8 +18,8 @@ APP_REPLICAS=$(kubectl get deployment/django-app -o jsonpath='{.spec.replicas}' 
 WORKER_REPLICAS=$(kubectl get deployment/django-worker -o jsonpath='{.spec.replicas}' 2>/dev/null || echo 1)
 
 echo "==> Scaling down app (${APP_REPLICAS} replicas) and worker (${WORKER_REPLICAS} replicas)..."
-just rscale-down django-app
-just rscale-down django-worker
+just --yes rscale-down django-app
+just --yes rscale-down django-worker
 
 echo "==> Starting in-cluster restore pod for: ${FILENAME}"
 kubectl delete pod db-restore --ignore-not-found=true
@@ -106,8 +106,8 @@ kubectl logs pod/db-restore -c restore
 kubectl delete pod db-restore
 
 echo "==> Scaling app back up to ${APP_REPLICAS} replicas..."
-just rscale-up django-app "${APP_REPLICAS}"
-just rscale-up django-worker "${WORKER_REPLICAS}"
+just --yes rscale-up django-app "${APP_REPLICAS}"
+just --yes rscale-up django-worker "${WORKER_REPLICAS}"
 
 echo ""
 echo "Done. Run: just rdj migrate"

--- a/template/justfile
+++ b/template/justfile
@@ -224,7 +224,8 @@ rpsql:
 
 # Run kubectl commands on the production cluster
 [group('production')]
-kube *args:
+[confirm("WARNING!!! Are you sure you want to run this command on production? (y/N)")]
+rkube *args:
     kubectl --kubeconfig {{ kubeconfig }} {{ args }}
 
 # Trigger an immediate database backup on the production cluster (requires backup.enabled: true)
@@ -244,6 +245,7 @@ rdb-restore filename:
 # Scale a production deployment to 0 replicas and wait for pods to terminate
 # Usage: just rscale-down <service>  e.g. just rscale-down django-app
 [group('production')]
+[confirm("WARNING!!! Are you sure you want to run this command on production? (y/N)")]
 rscale-down service:
     kubectl --kubeconfig {{ kubeconfig }} scale deployment/{{ service }} --replicas=0
     kubectl --kubeconfig {{ kubeconfig }} wait --for=delete pod -l app={{ service }} --timeout=60s 2>/dev/null || true
@@ -251,12 +253,14 @@ rscale-down service:
 # Scale a production deployment to a given replica count
 # Usage: just rscale-up <service> <count>  e.g. just rscale-up django-app 2
 [group('production')]
+[confirm("WARNING!!! Are you sure you want to run this command on production? (y/N)")]
 rscale-up service count:
     kubectl --kubeconfig {{ kubeconfig }} scale deployment/{{ service }} --replicas={{ count }}
 
 # Suspend CronJobs on the production cluster. Suspends all if no name given.
 # Usage: just rcrons-disable [name]  e.g. just rcrons-disable postgres-backup
 [group('production')]
+[confirm("WARNING!!! Are you sure you want to run this command on production? (y/N)")]
 rcrons-disable name="":
     #!/usr/bin/env bash
     set -euo pipefail
@@ -273,6 +277,7 @@ rcrons-disable name="":
 # Resume CronJobs on the production cluster. Resumes all if no name given.
 # Usage: just rcrons-enable [name]  e.g. just rcrons-enable postgres-backup
 [group('production')]
+[confirm("WARNING!!! Are you sure you want to run this command on production? (y/N)")]
 rcrons-enable name="":
     #!/usr/bin/env bash
     set -euo pipefail


### PR DESCRIPTION
Renames `just kube` to `just rkube` and adds `[confirm]` gates to all production `r*` commands that were missing them.

## Why

All production commands use an `r` prefix to distinguish them from local dev commands. `kube` was the odd one out. Completing the rename makes the convention consistent and easier to follow.

With the rename done, all `r*` commands now have `[confirm]` gates so a typo or muscle-memory mistake can't accidentally hit production. Previously `rkube`, `rscale-down`, `rscale-up`, `rcrons-disable`, and `rcrons-enable` had no confirmation.

## The `just --yes` convention

Interactive confirmation breaks automated agent flows (skills) that have already obtained user agreement at a higher level. `just --yes` bypasses `[confirm]` without removing the safety for direct human use. All skill SKILL.md files are updated to use `just --yes r*` for production command invocations. `db_restore.sh.jinja` is also updated since it calls `rscale-down`/`rscale-up` programmatically.

The convention is documented in `AGENTS.md.jinja` under a new "Production commands (r prefix)" section so future skills know the pattern.

## Changes

- `justfile`: `kube` → `rkube` with `[confirm]`; add `[confirm]` to `rscale-down`, `rscale-up`, `rcrons-disable`, `rcrons-enable`
- `db_restore.sh.jinja`: `just --yes rscale-*` for automated scale calls
- All 5 skill SKILL.md files: `just r*` → `just --yes r*` for all production commands
- `docs/database-backups.md`, `docs/deployment.md`: `just kube` → `just rkube`
- `AGENTS.md.jinja`: new production commands section with `just --yes` guidance