### PR TITLE
feat(skills): Add dj-db-backup skill for on-demand database snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Generated projects include `dj-*` Claude Code and OpenCode slash commands for co
 | `/dj-scale [n]`            | View or change the webapp replica count                                        |
 | `/dj-rotate-secrets`       | Rotate auto-generated and third-party Helm secrets and redeploy                |
 | `/dj-enable-db-backups`    | Enable automated daily PostgreSQL backups to a private Object Storage bucket   |
+| `/dj-db-backup`            | Trigger an immediate database backup without waiting for the daily cron        |
 | `/dj-db-restore`           | Guided production database restore from Object Storage backup                  |
 
 ## MCP Servers

--- a/template/.agents/skills/dj-db-backup/SKILL.md
+++ b/template/.agents/skills/dj-db-backup/SKILL.md
@@ -1,0 +1,63 @@
+---
+description: Trigger an immediate production database backup without waiting for the daily cron
+---
+
+Take an on-demand snapshot of the production database and upload it to Object Storage.
+Useful before deployments, migrations, or any operation that modifies data.
+
+## Required reading
+
+- `docs/database-backups.md`
+
+---
+
+## Step 1 — Check backups are configured
+
+```bash
+just --yes rkube get secret backup-secret --ignore-not-found -o name
+```
+
+If the output is empty, tell the user:
+
+> Backups are not configured on this cluster. Run `/dj-enable-db-backups` to set up
+> automated backups first.
+
+Stop.
+
+---
+
+## Step 2 — Confirm
+
+Tell the user:
+
+> This will trigger an immediate database backup and upload it to Object Storage.
+> The site stays up — no downtime required.
+> Proceed? [y/n]
+
+If no, stop.
+
+---
+
+## Step 3 — Run the backup
+
+```bash
+just --yes rdb-backup
+```
+
+This creates a one-off Kubernetes job from the `postgres-backup` CronJob, waits for it
+to complete (timeout: 5 minutes), streams the logs, then deletes the job.
+
+If the command exits non-zero, show the error output and tell the user:
+
+> Backup failed. Check the logs above. Common causes:
+> - Database unreachable — check `just rkube get pods`
+> - Object Storage credentials incorrect — check `backup-secret` and `values.secret.yaml`
+
+---
+
+## Step 4 — Done
+
+Tell the user:
+
+> Backup complete. The new snapshot is now available in Object Storage and will appear
+> when you next run `/dj-db-restore`.

--- a/template/.agents/skills/dj-db-backup/resources/help.md
+++ b/template/.agents/skills/dj-db-backup/resources/help.md
@@ -1,0 +1,16 @@
+**/dj-db-backup**
+
+Trigger an immediate production database backup without waiting for the daily cron job.
+
+Useful before deployments, risky migrations, or any operation you want to snapshot first.
+The site stays up — no downtime required.
+
+**Prerequisites:** Backups must be configured (`/dj-enable-db-backups`).
+
+**Example:**
+
+```
+/dj-db-backup
+```
+
+The backup is uploaded to Hetzner Object Storage and will appear when you run `/dj-db-restore`.

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -207,6 +207,7 @@ Available in Claude Code and OpenCode as `/dj-<command>`.
 | `/dj-scale [n]` | View or change the webapp replica count |
 | `/dj-rotate-secrets` | Rotate auto-generated and third-party Helm secrets and redeploy |
 | `/dj-enable-db-backups` | Enable automated daily PostgreSQL backups to Object Storage |
+| `/dj-db-backup`         | Trigger an immediate database backup without waiting for the daily cron |
 | `/dj-db-restore`        | Guided production database restore from Object Storage backup |
 
 

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -104,6 +104,7 @@ Available in Claude Code and OpenCode as `/dj-<command>`:
 | `/dj-scale [n]`            | View or change the webapp replica count                                        |
 | `/dj-rotate-secrets`       | Rotate auto-generated and third-party Helm secrets and redeploy                |
 | `/dj-enable-db-backups`    | Enable automated daily PostgreSQL backups to a private Object Storage bucket   |
+| `/dj-db-backup`            | Trigger an immediate database backup without waiting for the daily cron        |
 | `/dj-db-restore`           | Guided production database restore from Object Storage backup                  |
 
 ## MCP Servers


### PR DESCRIPTION
Adds `/dj-db-backup` as a companion to `/dj-db-restore`.

Wraps `just rdb-backup` with a pre-flight check (backup credentials must exist in the cluster) and a confirmation step before triggering the job. The underlying command already handles everything — job creation, wait, log streaming, and cleanup — so the skill stays thin.

Useful before deployments, risky migrations, or any time you want a point-in-time snapshot without waiting for the daily 03:00 UTC cron.

No downtime required; the site stays up throughout.