### PR TITLE
fix(dj-db-restore): fix list-backups for non-interactive use and make restore atomic

### DIFF
--- a/template/.agents/skills/dj-db-restore/SKILL.md
+++ b/template/.agents/skills/dj-db-restore/SKILL.md
@@ -66,66 +66,23 @@ If no, stop.
 
 ---
 
-## Step 4 — Disable CronJobs
-
-Suspend all CronJobs to prevent scheduled tasks from firing during the restore:
-
-```bash
-just --yes rcrons-disable
-```
-
----
-
-## Step 5 — Take a safety backup
-
-Trigger an immediate backup before overwriting the database:
-
-```bash
-just --yes rkube create job postgres-backup-pre-restore --from=cronjob/postgres-backup
-```
-
-Wait for it to complete (timeout: 5 minutes):
-
-```bash
-just --yes rkube wait --for=condition=complete job/postgres-backup-pre-restore --timeout=300s
-```
-
-If the job fails or times out, tell the user:
-
-> Safety backup failed. The restore has been paused. Re-enable CronJobs with:
->
-> ```bash
-> just rcrons-enable
-> ```
->
-> Then check the backup job logs:
->
-> ```bash
-> just rkube logs job/postgres-backup-pre-restore --all-containers
-> ```
-
-Stop without proceeding to the restore.
-
-Clean up the job after success:
-
-```bash
-just --yes rkube delete job postgres-backup-pre-restore
-```
-
----
-
-## Step 6 — Restore the backup
+## Step 4 — Restore the backup
 
 ```bash
 just --yes rdb-restore <selected-filename>
 ```
 
-Confirm the prompt when asked. The script scales down the app and worker, runs the
-in-cluster restore pod, then scales them back up to their original replica counts.
+The script handles the full restore atomically:
+1. Suspends all CronJobs
+2. Scales down the app and worker
+3. Takes a safety backup (after scale-down, no in-flight writes)
+4. Runs the in-cluster restore pod
+5. Scales the app and worker back up
+6. Resumes all CronJobs (even if interrupted)
 
 ---
 
-## Step 7 — Verify
+## Step 5 — Verify
 
 Run migrations to confirm the restored database is consistent:
 
@@ -138,15 +95,7 @@ before proceeding.
 
 ---
 
-## Step 8 — Re-enable CronJobs
-
-```bash
-just --yes rcrons-enable
-```
-
----
-
-## Step 9 — Done
+## Step 6 — Done
 
 Tell the user:
 

--- a/template/.agents/skills/dj-db-restore/bin/list-backups.sh
+++ b/template/.agents/skills/dj-db-restore/bin/list-backups.sh
@@ -8,15 +8,29 @@
 #   .agents/skills/dj-db-restore/bin/list-backups.sh
 set -euo pipefail
 
-# shellcheck disable=SC1073,SC2016
-# SC1073: shellcheck cannot parse `just` (not a standard shell command)
+# Read the aws-cli image from the backup CronJob so the version matches exactly.
+AWS_CLI_IMAGE=$(just --yes rkube get cronjob postgres-backup \
+  -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[0].image}')
+
+# Delete any stale pod from a previous interrupted run.
+just --yes rkube delete pod list-backups --ignore-not-found=true
+
+# Clean up the pod on exit regardless of how the script terminates.
+trap 'just --yes rkube delete pod list-backups --ignore-not-found=true 2>/dev/null || true' EXIT
+
+# shellcheck disable=SC2016
 # SC2016: vars in single quotes intentionally expand inside the container pod, not locally
-just --yes rkube run --rm -it list-backups \
-  --image=amazon/aws-cli:2 \
+just --yes rkube run list-backups \
+  --image="${AWS_CLI_IMAGE}" \
   --restart=Never \
   --env="AWS_ACCESS_KEY_ID=$(just --yes rkube get secret backup-secret -o jsonpath='{.data.BACKUP_ACCESS_KEY}' | base64 -d)" \
   --env="AWS_SECRET_ACCESS_KEY=$(just --yes rkube get secret backup-secret -o jsonpath='{.data.BACKUP_SECRET_KEY}' | base64 -d)" \
   --env="AWS_DEFAULT_REGION=$(just --yes rkube get secret backup-secret -o jsonpath='{.data.BACKUP_REGION}' | base64 -d)" \
   --env="BACKUP_ENDPOINT=$(just --yes rkube get secret backup-secret -o jsonpath='{.data.BACKUP_ENDPOINT}' | base64 -d)" \
   --env="BACKUP_BUCKET=$(just --yes rkube get secret backup-secret -o jsonpath='{.data.BACKUP_BUCKET}' | base64 -d)" \
-  -- sh -c 'aws --endpoint-url "$BACKUP_ENDPOINT" s3 ls s3://$BACKUP_BUCKET/ | sort'
+  --command -- sh -c 'aws --endpoint-url "$BACKUP_ENDPOINT" s3 ls "s3://$BACKUP_BUCKET/" | sort'
+
+just --yes rkube wait --for=jsonpath='{.status.phase}'=Succeeded pod/list-backups --timeout=120s \
+  || { echo "Failed to list backups. Logs:"; just --yes rkube logs pod/list-backups; exit 1; }
+
+just --yes rkube logs pod/list-backups

--- a/template/just/db_restore.sh.jinja
+++ b/template/just/db_restore.sh.jinja
@@ -17,9 +17,32 @@ POSTGRES_IMAGE=$(kubectl get statefulset postgres -o jsonpath='{.spec.template.s
 APP_REPLICAS=$(kubectl get deployment/django-app -o jsonpath='{.spec.replicas}' 2>/dev/null || echo 1)
 WORKER_REPLICAS=$(kubectl get deployment/django-worker -o jsonpath='{.spec.replicas}' 2>/dev/null || echo 1)
 
+# Resume CronJobs on exit (normal or interrupted) so they are never left suspended.
+_resume_cronjobs() {
+    echo "==> Resuming CronJobs..."
+    while IFS= read -r cj; do
+        kubectl patch "$cj" -p '{"spec":{"suspend":false}}' 2>/dev/null || true
+    done < <(kubectl get cronjobs -o name 2>/dev/null)
+    echo "All CronJobs resumed."
+}
+trap _resume_cronjobs EXIT
+
+echo "==> Suspending CronJobs..."
+while IFS= read -r cj; do
+    kubectl patch "$cj" -p '{"spec":{"suspend":true}}'
+done < <(kubectl get cronjobs -o name 2>/dev/null)
+echo "All CronJobs suspended."
+
 echo "==> Scaling down app (${APP_REPLICAS} replicas) and worker (${WORKER_REPLICAS} replicas)..."
 just --yes rscale-down django-app
 just --yes rscale-down django-worker
+
+echo "==> Taking safety backup (app is down, no in-flight writes)..."
+kubectl delete job postgres-backup-pre-restore --ignore-not-found=true
+kubectl create job postgres-backup-pre-restore --from=cronjob/postgres-backup
+kubectl wait --for=condition=complete job/postgres-backup-pre-restore --timeout=300s \
+  || { echo "Safety backup failed. Logs:"; kubectl logs job/postgres-backup-pre-restore --all-containers; kubectl delete job postgres-backup-pre-restore --ignore-not-found=true; exit 1; }
+kubectl delete job postgres-backup-pre-restore
 
 echo "==> Starting in-cluster restore pod for: ${FILENAME}"
 kubectl delete pod db-restore --ignore-not-found=true
@@ -111,3 +134,4 @@ just --yes rscale-up django-worker "${WORKER_REPLICAS}"
 
 echo ""
 echo "Done. Run: just rdj migrate"
+# trap EXIT fires here, resuming CronJobs


### PR DESCRIPTION
`/dj-db-restore` was broken in agent (no-TTY) contexts due to several bugs in `list-backups.sh`, and had structural issues that could leave the cluster in a bad state if interrupted.

**`list-backups.sh` fixes:**

- Replace `--rm -it` with `--restart=Never` + `kubectl wait` + `kubectl logs` + `kubectl delete`. `--rm -it` requires a TTY; without one, env vars inside the pod are unbound (`sh: BACKUP_ENDPOINT: unbound variable`).
- Add `EXIT` trap to delete the pod on interruption, preventing `AlreadyExists` errors on subsequent runs.
- Read the aws-cli image dynamically from the `postgres-backup` CronJob spec instead of using the floating `amazon/aws-cli:2` tag, which fails on clusters that have the pinned version cached.
- Add `--command` flag so `sh -c '...'` overrides the `aws` ENTRYPOINT rather than being passed as an AWS subcommand.

**`db_restore.sh` structural fixes:**

- Move CronJob suspend/resume inside the script with an `EXIT` trap. Previously the skill had separate steps 4 and 8 for this; if interrupted between them, CronJobs were left suspended indefinitely. The trap guarantees resume on any exit.
- Move the safety backup to after scale-down. Previously it ran while the app was still up, risking in-flight writes in the snapshot.

**SKILL.md** simplified from 9 steps to 6: the cron disable, safety backup, and cron enable steps are removed since `rdb-restore` now handles all of that atomically.

Fixes #304