### PR TITLE
ref: Rename just/manage.sh to rmanage.sh for consistency

### DIFF
--- a/template/just/rmanage.sh.jinja
+++ b/template/just/rmanage.sh.jinja
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Run Django manage.py commands inside the production django-app pod.
-# Usage: manage.sh <manage_command> [args...]
-# Example: manage.sh migrate
+# Usage: rmanage.sh <manage_command> [args...]
+# Example: rmanage.sh migrate
 set -euo pipefail
 
 export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/{{ project_slug }}.yaml}"

--- a/template/justfile
+++ b/template/justfile
@@ -214,13 +214,13 @@ terraform-value dir name:
 [group('production')]
 [confirm("WARNING!!! Are you sure you want to run this command on production? (y/N)")]
 rdj *args:
-    {{ script_dir }}/manage.sh {{ args }}
+    {{ script_dir }}/rmanage.sh {{ args }}
 
 # Open a psql shell on the production database via Django dbshell
 [group('production')]
 [confirm("WARNING!!! Are you sure you want to run this command on production? (y/N)")]
 rpsql:
-    {{ script_dir }}/manage.sh dbshell
+    {{ script_dir }}/rmanage.sh dbshell
 
 # Run kubectl commands on the production cluster
 [group('production')]


### PR DESCRIPTION
Rename `just/manage.sh.jinja` to `just/rmanage.sh.jinja`.

The script runs `manage.py` on the remote production pod via `kubectl exec`.
All other remote-operation scripts under `just/` use the `r`-prefix convention
(`rmanage.sh`, `list-backups.sh` calls `rkube`, etc.). The old name `manage.sh`
was inconsistent — `rmanage.sh` makes the remote nature clear at a glance.

The `template/manage.sh` in-container script is unchanged; that name is correct
since it runs locally inside the pod.