### PR TITLE
fix(dj-scale): wrong recipe name, missing plan step, kubectl KUBECONFIG

### DIFF
--- a/template/.agents/skills/dj-scale/SKILL.md
+++ b/template/.agents/skills/dj-scale/SKILL.md
@@ -67,12 +67,7 @@ If `<n>` > `webapp_count`, advise:
 
 > You're scaling to `<n>` replicas but only have `<webapp_count>` Hetzner
 > node(s). Consider increasing `webapp_count` in
-> `terraform/hetzner/terraform.tfvars` to `<n>` and running:
->
-> ```bash
-> just terraform hetzner plan
-> just terraform hetzner apply -auto-approve
-> ```
+> `terraform/hetzner/terraform.tfvars` to `<n>` first.
 >
 > Provision additional nodes first? [y/n]
 
@@ -82,7 +77,11 @@ If yes, update `webapp_count` in `terraform.tfvars` and run:
 just terraform hetzner plan
 ```
 
-Show the plan output and wait for user confirmation before running:
+Show the plan output, then ask:
+
+> Proceed with apply? [y/n]
+
+If yes:
 
 ```bash
 just terraform hetzner apply -auto-approve


### PR DESCRIPTION
## Summary

- Replace `just tf` with `just terraform` (the actual recipe name in the Justfile)
- Add plan-then-apply pattern before provisioning nodes: show `just terraform hetzner plan` output and wait for confirmation before running apply
- Replace bare `kubectl get pods` with `just --yes rkube get pods` so the verify step uses the correct kubeconfig

Closes #310