### PR TITLE
fix(dj-rotate-secrets): kubectl directly + psql as postgres user

### DIFF
--- a/template/.agents/skills/dj-rotate-secrets/SKILL.md
+++ b/template/.agents/skills/dj-rotate-secrets/SKILL.md
@@ -179,9 +179,19 @@ secrets:
 cache services. Otherwise the app will restart with new credentials while the
 services still expect the old ones, causing immediate 500 errors.
 
+These commands call `kubectl` directly — `just rkube` passes arguments through the
+shell which breaks quoted strings. Export `KUBECONFIG` first so kubectl finds the
+cluster:
+
+```bash
+export KUBECONFIG="$HOME/.kube/<project-slug>.yaml"
+```
+
+Replace `<project-slug>` with the value of `project_slug` from `.copier-answers.yml`.
+
 **PostgreSQL:**
 ```bash
-kubectl --kubeconfig "$(just --evaluate kubeconfig)" exec postgres-0 -- su postgres -c "psql -U postgres -c \"ALTER USER postgres PASSWORD '<new_postgres_password>';\""
+kubectl exec postgres-0 -- su postgres -c "psql -U postgres -c \"ALTER USER postgres PASSWORD '<new_postgres_password>';\""
 ```
 
 **Verify** the output contains `ALTER ROLE`. If it does not (empty output, error, or
@@ -199,7 +209,7 @@ If **manual**, stop and tell the user to re-run `/dj-rotate-secrets` when ready.
 
 **Redis:**
 ```bash
-kubectl --kubeconfig "$(just --evaluate kubeconfig)" exec deploy/redis -- redis-cli -a "<old_redis_password>" CONFIG SET requirepass "<new_redis_password>"
+kubectl exec deploy/redis -- redis-cli -a "<old_redis_password>" CONFIG SET requirepass "<new_redis_password>"
 ```
 
 **Verify** the output contains `OK`. If it does not, **stop immediately**. Tell the
@@ -223,13 +233,12 @@ including the full connection-string keys (`DATABASE_URL`, `REDIS_URL`) that
 embed the passwords.
 
 Build base64-encoded values for every key that changed and patch them in one
-call:
+call (`KUBECONFIG` is already exported from step 5a):
 
 ```bash
 NEW_POSTGRES_PASSWORD="$new_postgres" \
 NEW_REDIS_PASSWORD="$new_redis" \
 NAMESPACE="$namespace" \
-KUBECONFIG="$(just --evaluate kubeconfig)" \
   .agents/skills/dj-rotate-secrets/bin/patch-k8s-secrets.sh
 ```
 

--- a/template/.agents/skills/dj-rotate-secrets/SKILL.md
+++ b/template/.agents/skills/dj-rotate-secrets/SKILL.md
@@ -181,7 +181,7 @@ services still expect the old ones, causing immediate 500 errors.
 
 **PostgreSQL:**
 ```bash
-just --yes rkube exec postgres-0 -- su postgres -c "psql -U postgres -c \"ALTER USER postgres PASSWORD '<new_postgres_password>';\""
+kubectl --kubeconfig "$(just --evaluate kubeconfig)" exec postgres-0 -- su postgres -c "psql -U postgres -c \"ALTER USER postgres PASSWORD '<new_postgres_password>';\""
 ```
 
 **Verify** the output contains `ALTER ROLE`. If it does not (empty output, error, or
@@ -199,7 +199,7 @@ If **manual**, stop and tell the user to re-run `/dj-rotate-secrets` when ready.
 
 **Redis:**
 ```bash
-just --yes rkube exec deploy/redis -- redis-cli -a "<old_redis_password>" CONFIG SET requirepass "<new_redis_password>"
+kubectl --kubeconfig "$(just --evaluate kubeconfig)" exec deploy/redis -- redis-cli -a "<old_redis_password>" CONFIG SET requirepass "<new_redis_password>"
 ```
 
 **Verify** the output contains `OK`. If it does not, **stop immediately**. Tell the

--- a/template/.agents/skills/dj-rotate-secrets/SKILL.md
+++ b/template/.agents/skills/dj-rotate-secrets/SKILL.md
@@ -181,7 +181,7 @@ services still expect the old ones, causing immediate 500 errors.
 
 **PostgreSQL:**
 ```bash
-just --yes rkube exec postgres-0 -- bash -c "psql -U postgres -c \"ALTER USER postgres PASSWORD '<new_postgres_password>';\""
+just --yes rkube exec postgres-0 -- su postgres -c "psql -U postgres -c \"ALTER USER postgres PASSWORD '<new_postgres_password>';\""
 ```
 
 **Verify** the output contains `ALTER ROLE`. If it does not (empty output, error, or
@@ -229,6 +229,7 @@ call:
 NEW_POSTGRES_PASSWORD="$new_postgres" \
 NEW_REDIS_PASSWORD="$new_redis" \
 NAMESPACE="$namespace" \
+KUBECONFIG="$(just --evaluate kubeconfig)" \
   .agents/skills/dj-rotate-secrets/bin/patch-k8s-secrets.sh
 ```
 

--- a/template/.agents/skills/dj-rotate-secrets/bin/patch-k8s-secrets.sh
+++ b/template/.agents/skills/dj-rotate-secrets/bin/patch-k8s-secrets.sh
@@ -8,6 +8,7 @@
 #   NEW_POSTGRES_PASSWORD  — new PostgreSQL password
 #   NEW_REDIS_PASSWORD     — new Redis password
 #   NAMESPACE              — Helm release namespace
+#   KUBECONFIG             — path to kubeconfig (defaults to ~/.kube/<project>.yaml via just)
 #
 # Usage:
 #   NEW_POSTGRES_PASSWORD=... NEW_REDIS_PASSWORD=... NAMESPACE=... \
@@ -25,10 +26,8 @@ b64_redis_pass=$(printf '%s' "$NEW_REDIS_PASSWORD" | base64 -w0)
 b64_redis_url=$(printf 'redis://default:%s@redis.%s.svc.cluster.local:6379/0' \
   "$NEW_REDIS_PASSWORD" "$NAMESPACE" | base64 -w0)
 
-# shellcheck disable=SC1073  # shellcheck cannot parse `just` (not a standard shell command)
-just --yes rkube patch secret secrets -p "{\"data\":{
-  \"POSTGRES_PASSWORD\":\"$b64_pg_pass\",
-  \"DATABASE_URL\":\"$b64_db_url\",
-  \"REDIS_PASSWORD\":\"$b64_redis_pass\",
-  \"REDIS_URL\":\"$b64_redis_url\"
-}}"
+# Call kubectl directly — `just rkube` passes args through the shell which splits
+# the JSON on embedded newlines before kubectl receives the argument.
+kubectl patch secret secrets \
+  --namespace "$NAMESPACE" \
+  -p "{\"data\":{\"POSTGRES_PASSWORD\":\"$b64_pg_pass\",\"DATABASE_URL\":\"$b64_db_url\",\"REDIS_PASSWORD\":\"$b64_redis_pass\",\"REDIS_URL\":\"$b64_redis_url\"}}"


### PR DESCRIPTION
## Summary

- **Bug 1:** `patch-k8s-secrets.sh` now calls `kubectl` directly instead of `just rkube`, preventing the shell from splitting the JSON patch argument on embedded newlines. `KUBECONFIG` is passed explicitly from `just --evaluate kubeconfig`.
- **Bug 2:** PostgreSQL password update now runs `su postgres -c "psql ..."` inside the container, avoiding the `role "root" does not exist` error when `kubectl exec` runs as root.

Closes #314