### PR TITLE
fix: use email instead of username in E2E auth tests

### DIFF
--- a/template/{{ package_name }}/tests/e2e_fixtures.py.jinja
+++ b/template/{{ package_name }}/tests/e2e_fixtures.py.jinja
@@ -23,7 +23,7 @@ def auth_page(page: Page, e2e_user, live_server) -> Page:
     """Playwright page authenticated as e2e_user."""
     login_url = f"{live_server.url}{reverse('account_login')}"
     page.goto(login_url)
-    page.locator('[name="login"]').fill(e2e_user.username)
+    page.locator('[name="login"]').fill(e2e_user.email)
     page.locator('[name="password"]').fill("testpass")
     page.get_by_role("button", name="Sign In").click()
     return page

--- a/template/{{ package_name }}/users/tests/test_playwright.py
+++ b/template/{{ package_name }}/users/tests/test_playwright.py
@@ -12,18 +12,17 @@ pytestmark = [pytest.mark.e2e, pytest.mark.django_db(transaction=True)]
 def test_login_valid_credentials(page: Page, e2e_user, live_server):
     login_url = f"{live_server.url}{reverse('account_login')}"
     page.goto(login_url)
-    page.locator('[name="login"]').fill(e2e_user.username)
+    page.locator('[name="login"]').fill(e2e_user.email)
     page.locator('[name="password"]').fill("testpass")
     page.get_by_role("button", name="Sign In").click()
     home_url = f"{live_server.url}{reverse('index')}"
-    page.wait_for_url(home_url)
     expect(page).to_have_url(home_url)
 
 
 def test_login_invalid_credentials(page: Page, e2e_user, live_server):
     login_url = f"{live_server.url}{reverse('account_login')}"
     page.goto(login_url)
-    page.locator('[name="login"]').fill(e2e_user.username)
+    page.locator('[name="login"]').fill(e2e_user.email)
     page.locator('[name="password"]').fill("wrongpassword")
     page.get_by_role("button", name="Sign In").click()
     expect(page).to_have_url(login_url)


### PR DESCRIPTION
## Summary

- Replace `e2e_user.username` with `e2e_user.email` in `users/tests/test_playwright.py` and `tests/e2e_fixtures.py` — the template sets `ACCOUNT_LOGIN_METHODS = {"email"}` so allauth rejects username-based logins
- Remove redundant `page.wait_for_url(home_url)` before `expect(page).to_have_url(home_url)` in `test_login_valid_credentials`

## Test plan

- [x] Pre-commit passes (3 passes)
- [x] `just typecheck` passes
- [x] 112 repo-level tests pass

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)