### PR TITLE
fix: remove PostToolUse ruff/djlint linter hooks from generated settings.json

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -187,29 +187,9 @@ def install_claude_hooks() -> None:
                             "type": "command",
                             "command": (
                                 "FILE=$(jq -r '.tool_input.file_path // empty');"
-                                ' if [ -n "$FILE" ]'
-                                " && echo \"$FILE\" | grep -q '\\.py$'"
-                                " && ! echo \"$FILE\" | grep -q '/migrations/';"
-                                ' then uv run ruff check --fix "$FILE"'
-                                ' && uv run ruff format "$FILE"; fi'
-                            ),
-                        },
-                        {
-                            "type": "command",
-                            "command": (
-                                "FILE=$(jq -r '.tool_input.file_path // empty');"
                                 " if echo \"$FILE\" | grep -qE '/models[^/]*\\.py$';"
                                 " then echo 'REMINDER: models file edited"
                                 " — run: just dj makemigrations'; fi"
-                            ),
-                        },
-                        {
-                            "type": "command",
-                            "command": (
-                                "FILE=$(jq -r '.tool_input.file_path // empty');"
-                                ' if [ -n "$FILE" ]'
-                                " && echo \"$FILE\" | grep -q '\\.html$';"
-                                ' then uv run djlint --lint "$FILE"; fi'
                             ),
                         },
                     ],


### PR DESCRIPTION
Removes the `ruff check --fix`, `ruff format`, and `djlint --lint` PostToolUse hooks from the generated `.claude/settings.json`.

These hooks run on every file edit and cause churn: ruff strips imports as unused before the usage is written in the next edit, forcing workarounds like rewriting entire files in one shot.

The PreToolUse hook that runs `just check-all` before any `git commit` is the correct lint gate. The migration reminder hook (models file edited → makemigrations) is retained.

Closes #326