### PR TITLE
docs: add tenants and SSE docs; split channels.md to WebSockets only

### DIFF
--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -139,7 +139,9 @@ actively, not as background reading.
 | Adding a JS/CSS dependency      | `docs/frontend-dependencies.md` |
 | Any feature handling user data, accounts, or PII | `docs/gdpr.md` |
 | Background task                 | `docs/django-tasks.md` |
-| Channels, SSE, WebSockets       | `docs/channels.md` |
+| Server-Sent Events (SSE)        | `docs/sse.md` |
+| WebSockets (Django Channels)    | `docs/channels.md` |
+| Multi-tenancy (django-tenants)  | `docs/tenants.md` |
 | HTMX interaction                | `docs/htmx.md` |
 | AlpineJS component              | `docs/alpine.md` |
 | Dropdown menus                            | `docs/ui-recipes.md` |

--- a/template/docs/channels.md
+++ b/template/docs/channels.md
@@ -1,12 +1,23 @@
-# Channels, SSE & WebSockets
+# WebSockets with Django Channels
 
-Real-time patterns for pushing data from the server to the browser.
+Bidirectional real-time communication using
+[`channels`](https://channels.readthedocs.io/) with
+[`channels-redis`](https://pypi.org/project/channels-redis/) as the channel
+layer. Redis is already in the stack.
+
+For one-way server push (notifications, live feeds, progress bars), use SSE
+instead — see `docs/sse.md`.
 
 ## Contents
 
 - [Choosing a Pattern](#choosing-a-pattern)
-- [Server-Sent Events with LISTEN/NOTIFY](#server-sent-events-with-listennotify)
-- [WebSockets with Django Channels](#websockets-with-django-channels)
+- [Install](#install)
+- [Local development server](#local-development-server)
+- [Settings](#settings)
+- [ASGI application](#asgi-application)
+- [Routing](#routing)
+- [Consumer](#consumer)
+- [Sending from outside a consumer](#sending-from-outside-a-consumer)
 - [Testing](#testing)
 - [HTMX Integration](#htmx-integration)
 
@@ -14,120 +25,41 @@ Real-time patterns for pushing data from the server to the browser.
 
 | Need | Pattern | Extra packages |
 | ---- | ------- | -------------- |
-| One-way push (notifications, live feed, progress) | SSE + psycopg LISTEN/NOTIFY | none |
+| One-way push (notifications, live feed, progress) | SSE + psycopg LISTEN/NOTIFY — see `docs/sse.md` | none |
 | Bidirectional messaging (chat, collaborative editing) | WebSockets + Django Channels | `channels`, `channels-redis` |
 
-Start with SSE — it is simpler, works over standard HTTP, and needs no extra
-dependencies. Only reach for WebSockets when you need the client to send
-messages back over the same connection.
-
-## Server-Sent Events with LISTEN/NOTIFY
-
-PostgreSQL LISTEN/NOTIFY delivers lightweight pub/sub over the existing database
-connection. Pair it with an async SSE view to push events to the browser.
-
-### Publishing a notification
-
-From Python (e.g. inside a django-tasks background task or a signal handler):
-
-```python
-import psycopg
-from psycopg import sql
-
-from django.conf import settings
-
-
-def send_notification(channel: str, payload: str) -> None:
-    with psycopg.connect(settings.DATABASE_URL) as conn:
-        conn.execute(
-            sql.SQL("NOTIFY {}, {}").format(
-                sql.Identifier(channel),
-                sql.Literal(payload),
-            )
-        )
-```
-
-Or from raw SQL (e.g. in a trigger):
-
-```sql
-NOTIFY new_comment, '{"comment_id": 42}';
-```
-
-### Async SSE view
-
-```python
-import asyncio
-import psycopg
-
-from django.conf import settings
-from django.http import StreamingHttpResponse
-from django.views.decorators.cache import never_cache
-
-
-@never_cache
-async def sse_notifications(request):
-    async def event_stream():
-        conn = await psycopg.AsyncConnection.connect(
-            settings.DATABASE_URL,
-            autocommit=True,
-        )
-        try:
-            await conn.execute("LISTEN notifications")
-            gen = conn.notifies()
-            async for notify in gen:
-                yield (
-                    f"event: notification\n"
-                    f"data: {notify.payload}\n\n"
-                )
-        finally:
-            await conn.close()
-
-    return StreamingHttpResponse(
-        event_stream(),
-        content_type="text/event-stream",
-    )
-```
-
-Register the view in `urls.py`:
-
-```python
-from django.urls import path
-
-from my_app.views import sse_notifications
-
-urlpatterns = [
-    path("sse/notifications/", sse_notifications, name="sse-notifications"),
-]
-```
-
-### Browser: connecting with the HTMX SSE extension
-
-See [HTMX Integration — SSE](#sse) below.
-
-For a plain JavaScript fallback:
-
-```javascript
-const source = new EventSource("/sse/notifications/");
-source.addEventListener("notification", (e) => {
-    const data = JSON.parse(e.data);
-    // update the DOM
-});
-```
-
-## WebSockets with Django Channels
-
-For bidirectional real-time communication, use
-[`channels`](https://channels.readthedocs.io/) with
-[`channels-redis`](https://pypi.org/project/channels-redis/) as the channel
-layer. Redis is already in the stack.
-
-### Install
+## Install
 
 ```bash
 uv add channels channels-redis
 ```
 
-### Settings
+## Local development server
+
+Django's built-in `runserver` does not support WebSockets. In local development,
+[Daphne](https://github.com/django/daphne) replaces it with an ASGI-capable
+version that handles WebSocket connections.
+
+Add `daphne` as a **dev-only** dependency and prepend it to `INSTALLED_APPS`
+when `DEBUG=True`. Daphne takes over `runserver` automatically — no changes to
+`just serve` are needed.
+
+```bash
+uv add --dev daphne
+```
+
+```python
+# config/settings.py
+if DEBUG:
+    # Daphne replaces runserver with an ASGI-capable version for WebSocket support.
+    # Dev-only dependency — must be first in INSTALLED_APPS.
+    INSTALLED_APPS = ["daphne", *INSTALLED_APPS]
+```
+
+In production the ASGI server (gunicorn + uvicorn workers or similar) handles
+WebSockets natively — `daphne` is not added to `INSTALLED_APPS` there.
+
+## Settings
 
 ```python
 # config/settings.py
@@ -149,13 +81,14 @@ CHANNEL_LAYERS = {
 }
 ```
 
-### ASGI application
+## ASGI application
 
 Update `config/asgi.py` to route WebSocket connections:
 
 ```python
 import os
 
+from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
 from django.core.asgi import get_asgi_application
 
@@ -168,14 +101,15 @@ from my_app.routing import websocket_urlpatterns  # noqa: E402
 application = ProtocolTypeRouter(
     {
         "http": django_asgi_app,
-        "websocket": URLRouter(websocket_urlpatterns),
+        "websocket": AuthMiddlewareStack(URLRouter(websocket_urlpatterns)),
     }
 )
 ```
 
-Uvicorn already supports WebSockets — no need to switch to Daphne.
+`AuthMiddlewareStack` populates `scope["user"]` from the session cookie so
+consumers can access `self.scope["user"]` without additional auth setup.
 
-### Routing
+## Routing
 
 Create `my_app/routing.py`:
 
@@ -189,7 +123,7 @@ websocket_urlpatterns = [
 ]
 ```
 
-### Consumer
+## Consumer
 
 ```python
 import json
@@ -220,7 +154,7 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):
         await self.send_json({"message": event["message"]})
 ```
 
-### Sending from outside a consumer
+## Sending from outside a consumer
 
 Use the channel layer from any Django code (views, tasks, signals):
 
@@ -238,34 +172,6 @@ def broadcast_to_room(room_name: str, message: str) -> None:
 ```
 
 ## Testing
-
-### SSE views
-
-Test the SSE view like any async Django view. Use `AsyncClient` and iterate
-over the streaming response:
-
-```python
-import pytest
-
-from django.test import AsyncClient
-
-
-@pytest.mark.django_db
-async def test_sse_notifications(mocker):
-    mock_notifies = mocker.patch(
-        "my_app.views.psycopg.AsyncConnection.connect"
-    )
-    # ... set up mock to yield test notifications
-
-    client = AsyncClient()
-    response = await client.get("/sse/notifications/")
-    assert response["Content-Type"] == "text/event-stream"
-```
-
-For integration tests, publish a real NOTIFY in the test database and verify
-the view yields the expected SSE event.
-
-### WebSocket consumers
 
 Django Channels provides `WebsocketCommunicator` for testing consumers
 without a real server. Use the in-memory channel layer in tests:
@@ -321,70 +227,10 @@ Key points:
 
 ## HTMX Integration
 
-Both SSE and WebSockets integrate with HTMX via dedicated extensions. See
-`docs/htmx.md` → [Extensions](htmx.md#extensions) for how to vendor and load
-them.
+Vendor the `htmx-ext-ws` extension (see `docs/htmx.md` → Extensions for how
+to vendor and load it; `vendors.json` key: `htmx-ext-ws`).
 
-| Pattern | Extension | `vendors.json` key |
-| ------- | --------- | ------------------ |
-| SSE | [`htmx-ext-sse`](https://htmx.org/extensions/sse/) | `htmx-ext-sse` |
-| WebSockets | [`htmx-ext-ws`](https://htmx.org/extensions/ws/) | `htmx-ext-ws` |
-
-### SSE
-
-Use `sse-connect` and `sse-swap` to subscribe to server events and swap content
-into the DOM:
-
-```html
-<div hx-ext="sse" sse-connect="{% url 'sse-notifications' %}" sse-swap="notification">
-    <!-- replaced with each incoming event -->
-    <p>Waiting for notifications...</p>
-</div>
-```
-
-The server must send events with a matching event name:
-
-```
-event: notification
-data: <p>New comment on your post</p>
-
-```
-
-Multiple event types on one connection:
-
-```html
-<div hx-ext="sse" sse-connect="{% url 'sse-feed' %}">
-    <div sse-swap="comment">No comments yet</div>
-    <div sse-swap="like">No likes yet</div>
-</div>
-```
-
-Use `hx-trigger="sse:<event>"` to fire an HTTP request when an event arrives
-(instead of swapping the event data directly):
-
-```html
-<div hx-ext="sse" sse-connect="{% url 'sse-feed' %}">
-    <div hx-get="{% url 'notifications-list' %}"
-         hx-trigger="sse:refresh"
-         hx-target="#notifications">
-    </div>
-</div>
-```
-
-Close the connection when the server sends a specific event:
-
-```html
-<div hx-ext="sse"
-     sse-connect="{% url 'sse-progress' %}"
-     sse-swap="progress"
-     sse-close="complete">
-</div>
-```
-
-### WebSockets
-
-Add the `htmx-ext-ws` extension, then use `ws-connect` to open a connection and
-`ws-send` on a form to transmit data:
+Use `ws-connect` to open a connection and `ws-send` on a form to transmit data:
 
 ```html
 <div hx-ext="ws" ws-connect="/ws/chat/lobby/">
@@ -415,9 +261,32 @@ htmx.createWebSocket = function(url) {
 };
 ```
 
+### Clearing the input after send (Alpine + htmx-ext-ws)
+
+After a `ws-send` form submits, use the `htmx:ws-after-send` event to clear
+the input. htmx dispatches events in both camelCase (`htmx:wsAfterSend`) and
+kebab-case (`htmx:ws-after-send`); use the kebab-case form with Alpine because
+the camelCase version contains a colon that confuses Alpine's `x-on:` directive
+parser.
+
+Add `x-data` for Alpine scope and `@htmx:ws-after-send` on the form:
+
+```html
+<form
+  x-data
+  ws-send
+  @submit.prevent
+  @htmx:ws-after-send="$refs.input.value = ''"
+>
+  <input x-ref="input" type="text" name="text_data" autocomplete="off">
+  <button type="submit">Send</button>
+</form>
+```
+
+Do **not** clear the input on `@submit.prevent` — Alpine fires before htmx
+reads the form values, which sends an empty payload over the WebSocket.
+
 ### References
 
-- [HTMX SSE extension](https://htmx.org/extensions/sse/)
 - [HTMX WebSocket extension](https://htmx.org/extensions/ws/)
 - [Django Channels docs](https://channels.readthedocs.io/)
-- [psycopg NOTIFY docs](https://www.psycopg.org/psycopg3/docs/advanced/async.html#asynchronous-notifications)

--- a/template/docs/htmx.md
+++ b/template/docs/htmx.md
@@ -312,7 +312,7 @@ Do not load extensions globally in `base.html` unless every page needs them.
 
 | Extension | Package | Use case | Docs |
 | --------- | ------- | -------- | ---- |
-| SSE | `htmx-ext-sse` | Server-Sent Events | `docs/channels.md` |
+| SSE | `htmx-ext-sse` | Server-Sent Events | `docs/sse.md` |
 | WebSocket | `htmx-ext-ws` | Bidirectional WebSockets | `docs/channels.md` |
 
 See [htmx.org/extensions](https://htmx.org/extensions/) for the full list.

--- a/template/docs/packages.md
+++ b/template/docs/packages.md
@@ -67,8 +67,8 @@ State your findings explicitly when suggesting a package — don't just name it.
   Redis cache backend (already configured).
 - **aiohttp**: use for async HTTP calls to third-party APIs. See
   `docs/api-integration.md` for the `USER_AGENT` setting, error handling, and testing patterns.
-- **channels**: for real-time (SSE and WebSockets). See `docs/channels.md` for
-  setup, consumers, and HTMX integration.
+- **channels**: for WebSocket-based real-time communication. See `docs/channels.md` for
+  setup, consumers, and HTMX integration. For one-way push (SSE), see `docs/sse.md`.
 - **django-money**: pairs with `py-moneyed`. Use `MoneyField` on models;
   arithmetic respects currency. `MoneyWidget` renders an amount input and a
   currency select side-by-side. See `docs/django-forms.md#moneywidget` for the

--- a/template/docs/sse.md
+++ b/template/docs/sse.md
@@ -1,0 +1,229 @@
+# Server-Sent Events
+
+One-way push from server to browser using PostgreSQL LISTEN/NOTIFY over an
+async streaming view.
+
+## Contents
+
+- [When to use SSE](#when-to-use-sse)
+- [Publishing a notification](#publishing-a-notification)
+- [Async SSE view](#async-sse-view)
+- [Testing](#testing)
+- [HTMX Integration](#htmx-integration)
+
+## When to use SSE
+
+| Need | Pattern |
+| ---- | ------- |
+| One-way push (notifications, live feed, progress) | SSE + psycopg LISTEN/NOTIFY |
+| Bidirectional messaging (chat, collaborative editing) | WebSockets — see `docs/channels.md` |
+
+Start with SSE — it is simpler, works over standard HTTP, and needs no extra
+dependencies. Only reach for WebSockets when you need the client to send
+messages back over the same connection.
+
+## Publishing a notification
+
+From Python (e.g. inside a django-tasks background task or a signal handler):
+
+```python
+import psycopg
+from psycopg import sql
+
+from django.conf import settings
+
+
+def send_notification(channel: str, payload: str) -> None:
+    with psycopg.connect(settings.DATABASE_URL) as conn:
+        conn.execute(
+            sql.SQL("NOTIFY {}, {}").format(
+                sql.Identifier(channel),
+                sql.Literal(payload),
+            )
+        )
+```
+
+Or from raw SQL (e.g. in a trigger):
+
+```sql
+NOTIFY new_comment, '{"comment_id": 42}';
+```
+
+## Async SSE view
+
+```python
+import psycopg
+
+from django.conf import settings
+from django.http import StreamingHttpResponse
+from django.views.decorators.cache import never_cache
+
+
+@never_cache
+async def sse_notifications(request):
+    async def event_stream():
+        conn = await psycopg.AsyncConnection.connect(
+            settings.DATABASE_URL,
+            autocommit=True,
+        )
+        try:
+            await conn.execute("LISTEN notifications")
+            gen = conn.notifies()
+            async for notify in gen:
+                yield (
+                    f"event: notification\n"
+                    f"data: {notify.payload}\n\n"
+                )
+        finally:
+            await conn.close()
+
+    return StreamingHttpResponse(
+        event_stream(),
+        content_type="text/event-stream",
+    )
+```
+
+Register the view in `urls.py`:
+
+```python
+from django.urls import path
+
+from my_app.views import sse_notifications
+
+urlpatterns = [
+    path("sse/notifications/", sse_notifications, name="sse-notifications"),
+]
+```
+
+### Browser: plain JavaScript fallback
+
+```javascript
+const source = new EventSource("/sse/notifications/");
+source.addEventListener("notification", (e) => {
+    const data = JSON.parse(e.data);
+    // update the DOM
+});
+```
+
+## Testing
+
+### Gotchas
+
+**Do not use `AsyncClient` for SSE views.** Django's test client (both sync
+and async) fully consumes streaming responses internally. An SSE async
+generator that blocks on `conn.notifies()` will hang the test forever — even
+with a mock that yields a finite number of items.
+
+**`RequestFactory` requests lack middleware attributes.** Decorators like
+`login_required` call `request.auser()`, which is added by
+`AuthenticationMiddleware`. Neither `RequestFactory` nor `AsyncRequestFactory`
+run middleware, so calling the decorated view directly raises
+`AttributeError`. Use `view.__wrapped__` to skip `login_required` and set
+`request.user` manually.
+
+### Recommended pattern
+
+Test the auth redirect with the **sync client** (works fine for async views).
+Test streaming behaviour by calling the **unwrapped view function** directly
+with `AsyncRequestFactory`:
+
+```python
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from my_app.views import sse_notifications
+
+
+@pytest.fixture
+def _mock_async_pg(mocker):
+    async def fake_notifies():
+        yield MagicMock(payload='{"count": 1}')
+
+    mock_conn = AsyncMock()
+    mock_conn.notifies = fake_notifies
+    mocker.patch(
+        "my_app.views.psycopg.AsyncConnection.connect",
+        new=AsyncMock(return_value=mock_conn),
+    )
+
+
+@pytest.mark.django_db
+class TestSseView:
+    def test_anonymous_redirected(self, client):
+        response = client.get("/sse/notifications/")
+        assert response.status_code == 302
+
+    async def test_returns_event_stream(self, user, _mock_async_pg, async_rf):
+        request = async_rf.get("/")
+        request.user = user
+        # Skip login_required — no middleware on request factory
+        response = await sse_notifications.__wrapped__(request)
+        assert response["Content-Type"] == "text/event-stream"
+
+    async def test_yields_sse_events(self, user, _mock_async_pg, async_rf):
+        request = async_rf.get("/")
+        request.user = user
+        response = await sse_notifications.__wrapped__(request)
+        content = b"".join([chunk async for chunk in response.streaming_content])
+        assert b"event: notification" in content
+```
+
+## HTMX Integration
+
+Vendor the `htmx-ext-sse` extension (see `docs/htmx.md` → Extensions for how
+to vendor and load it; `vendors.json` key: `htmx-ext-sse`).
+
+Use `sse-connect` and `sse-swap` to subscribe to server events and swap content
+into the DOM:
+
+```html
+<div hx-ext="sse" sse-connect="{% url 'sse-notifications' %}" sse-swap="notification">
+    <!-- replaced with each incoming event -->
+    <p>Waiting for notifications...</p>
+</div>
+```
+
+The server must send events with a matching event name:
+
+```
+event: notification
+data: <p>New comment on your post</p>
+
+```
+
+Multiple event types on one connection:
+
+```html
+<div hx-ext="sse" sse-connect="{% url 'sse-feed' %}">
+    <div sse-swap="comment">No comments yet</div>
+    <div sse-swap="like">No likes yet</div>
+</div>
+```
+
+Use `hx-trigger="sse:<event>"` to fire an HTTP request when an event arrives
+(instead of swapping the event data directly):
+
+```html
+<div hx-ext="sse" sse-connect="{% url 'sse-feed' %}">
+    <div hx-get="{% url 'notifications-list' %}"
+         hx-trigger="sse:refresh"
+         hx-target="#notifications">
+    </div>
+</div>
+```
+
+Close the connection when the server sends a specific event:
+
+```html
+<div hx-ext="sse"
+     sse-connect="{% url 'sse-progress' %}"
+     sse-swap="progress"
+     sse-close="complete">
+</div>
+```
+
+### References
+
+- [HTMX SSE extension](https://htmx.org/extensions/sse/)
+- [psycopg NOTIFY docs](https://www.psycopg.org/psycopg3/docs/advanced/async.html#asynchronous-notifications)

--- a/template/docs/tenants.md
+++ b/template/docs/tenants.md
@@ -1,0 +1,419 @@
+# Multi-tenancy with django-tenants
+
+This project uses [django-tenants](https://django-tenants.readthedocs.io/) for
+PostgreSQL schema-based multi-tenancy. Each tenant gets an isolated PostgreSQL
+schema; the public schema holds shared data (users, tenant registry, lookup
+tables).
+
+## Contents
+
+- [How it works](#how-it-works)
+- [SHARED\_APPS vs TENANT\_APPS](#shared_apps-vs-tenant_apps)
+- [Required settings](#required-settings)
+- [URL routing](#url-routing)
+- [Accessing the current tenant](#accessing-the-current-tenant)
+- [Tenant model](#tenant-model)
+- [File uploads](#file-uploads)
+- [Admin site customisation](#admin-site-customisation)
+- [Testing](#testing)
+- [Gotchas](#gotchas)
+
+---
+
+## How it works
+
+`TenantMainMiddleware` (always the **first** middleware) inspects the request
+hostname, looks up the matching `Domain` record, and sets:
+
+- `request.tenant` — the `Tenant` instance
+- `request.urlconf` — either `ROOT_URLCONF` (tenant subdomains) or
+  `PUBLIC_SCHEMA_URLCONF` (the public domain)
+- `connection.schema_name` — the active PostgreSQL schema for the request
+
+All subsequent ORM queries in that request run against the resolved schema.
+
+---
+
+## SHARED\_APPS vs TENANT\_APPS
+
+```python
+# config/settings.py
+SHARED_APPS = [
+    "django_tenants",
+    "modeltranslation",    # must come before django.contrib.admin
+    "django.contrib.admin",
+    # ... Django core + third-party apps
+    "my_package.tenants",  # Tenant, Domain models
+    "my_package.users",    # shared user identity
+    # ... other apps with data shared across all tenants
+]
+
+TENANT_APPS = [
+    "my_package.your_app",  # per-tenant data
+    # ... other per-tenant apps
+]
+
+INSTALLED_APPS = SHARED_APPS + [app for app in TENANT_APPS if app not in SHARED_APPS]
+```
+
+**Rules:**
+
+- `SHARED_APPS` — tables in the public schema only. Use for the tenant/domain
+  registry, shared user identity, platform-wide lookup data, and infrastructure
+  apps (background tasks, allauth, etc.).
+- `TENANT_APPS` — each tenant gets its own copy of these tables. Use for
+  per-organisation data.
+- `TENANT_APPS` must contain at least one app or django-tenants raises
+  `ImproperlyConfigured`.
+- `django_tasks_db` (background tasks) belongs in `SHARED_APPS` — it is
+  infrastructure, not tenant-specific data.
+- `modeltranslation` must appear **before** `django.contrib.admin` in
+  `SHARED_APPS`.
+
+---
+
+## Required settings
+
+```python
+DATABASE_ENGINE = "django_tenants.postgresql_backend"
+DATABASE_ROUTERS = ["django_tenants.routers.TenantSyncRouter"]
+
+TENANT_MODEL = "tenants.Tenant"
+TENANT_DOMAIN_MODEL = "tenants.Domain"   # NOTE: not DOMAIN_MODEL
+PUBLIC_SCHEMA_NAME = "public"
+PUBLIC_SCHEMA_URLCONF = "config.urls.public"
+ROOT_URLCONF = "config.urls.tenant"      # tenant subdomains
+```
+
+> **Gotcha:** The setting is `TENANT_DOMAIN_MODEL`, not `DOMAIN_MODEL`.
+> Using `DOMAIN_MODEL` causes `AttributeError: 'Settings' object has no
+> attribute 'TENANT_DOMAIN_MODEL'` at startup or on the first request.
+
+---
+
+## URL routing
+
+Two URL confs serve different audiences:
+
+| URL conf | Domain | Serves |
+|---|---|---|
+| `config.urls.public` | Public domain (`PUBLIC_SCHEMA_URLCONF`) | Landing page, auth, admin, infra endpoints |
+| `config.urls.tenant` | Tenant subdomains (`ROOT_URLCONF`) | Application UI |
+
+django-tenants has no built-in concept of shared URL patterns (unlike `SHARED_APPS` /
+`TENANT_APPS`). The two URL confs are fully independent. To avoid duplicating patterns
+that must be reachable on every domain (admin, allauth, health checks, infrastructure
+endpoints, debug tools), define them once in `config/urls/shared.py` and import into
+both confs:
+
+```
+config/urls/
+    __init__.py   # empty
+    shared.py     # admin, allauth, health checks, robots.txt, i18n, debug tools
+    public.py     # index/about/privacy + shared_urlpatterns
+    tenant.py     # tenant index + shared_urlpatterns
+```
+
+```python
+# config/urls/shared.py
+from django.conf import settings
+from django.contrib import admin
+
+urlpatterns = [
+    path(settings.ADMIN_URL, admin.site.urls),
+    path("robots.txt", views.robots, name="robots"),
+    path("account/", include("allauth.urls")),
+    # health checks, debug toolbar, browser reload ...
+]
+
+# config/urls/tenant.py
+from config.urls.shared import urlpatterns as shared_urlpatterns
+
+urlpatterns = [
+    path("", views.tenant_home, name="index"),
+] + shared_urlpatterns
+
+# config/urls/public.py
+from config.urls.shared import urlpatterns as shared_urlpatterns
+
+urlpatterns = [
+    path("", views.index, name="index"),
+    path("about/", views.about, name="about"),
+] + shared_urlpatterns
+```
+
+Both URL confs expose `name="index"` so shared templates (e.g. the navbar logo link)
+can call `{% url 'index' %}` on any domain.
+
+---
+
+## Accessing the current tenant
+
+django-tenants sets the tenant on the **request object**, not on the connection:
+
+```python
+# CORRECT
+def my_view(request):
+    tenant = request.tenant   # Tenant instance
+
+# WRONG — connection.tenant is not set by TenantMainMiddleware
+def my_view(request):
+    from django.db import connection
+    tenant = connection.tenant  # AttributeError
+```
+
+The `tenant` attribute is typed on `my_package.http.request.HttpRequest` via a
+`TYPE_CHECKING` block, so views that use the typed request get full type inference:
+
+```python
+from my_package.http.request import HttpRequest
+
+def my_view(request: HttpRequest) -> ...:
+    tenant = request.tenant  # inferred as Tenant
+```
+
+In templates, pass the tenant explicitly from the view context:
+
+```python
+return TemplateResponse(request, "tenants/home.html", {"tenant": request.tenant})
+```
+
+---
+
+## Tenant model
+
+The `Tenant` model extends `TenantMixin`. `Domain` extends `DomainMixin`:
+
+```python
+from django_tenants.models import DomainMixin, TenantMixin
+from sorl.thumbnail import ImageField
+from my_package.uploads import UploadHandler
+
+class Tenant(TenantMixin):
+    name = models.CharField(_("name"), max_length=255)
+    logo = ImageField(_("logo"), upload_to=UploadHandler("tenants/logos"), blank=True)
+    auto_create_schema = True
+
+class Domain(DomainMixin):
+    pass
+```
+
+`auto_create_schema = True` causes django-tenants to create the tenant's
+PostgreSQL schema when the `Tenant` record is first saved.
+
+---
+
+## File uploads
+
+Tenant logos live in the **public schema** and use standard shared storage
+(S3 / local). No tenant-scoped storage is needed for `Tenant.logo`.
+
+For files uploaded *within* a tenant context (e.g. project attachments):
+django-tenants provides `TenantFileSystemStorage` which scopes files per tenant
+schema directory via `MULTITENANT_RELATIVE_MEDIA_ROOT`. In production with S3
+this is less relevant since S3 uses path prefixes — the `UploadHandler`
+UUID-based paths are sufficient for isolation.
+
+Always use `sorl.thumbnail.ImageField` (not `django.db.models.ImageField`) for
+image fields. It fires a `post_delete` signal that cleans up thumbnail cache
+entries from storage automatically. Add an explicit `post_delete` signal to
+delete the **original** file, since Django does not do this automatically:
+
+```python
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
+
+@receiver(post_delete, sender=Tenant)
+def _delete_tenant_logo(sender, instance, **kwargs) -> None:
+    instance.logo.delete(save=False)
+```
+
+---
+
+## Admin site customisation
+
+`TenantAwareAdminSite` overrides `each_context` to set `site_header` and
+`site_title` to `"{tenant.name} Admin"` on tenant subdomains and
+`"{site.name} Admin"` on the public domain.
+
+It is wired in via a custom `AdminConfig` subclass:
+
+```python
+# my_package/tenants/admin_config.py
+import django.contrib.admin.apps
+
+class TenantAdminConfig(django.contrib.admin.apps.AdminConfig):
+    default_site = "my_package.tenants.admin.TenantAwareAdminSite"
+```
+
+```python
+# config/settings.py  SHARED_APPS
+"my_package.tenants.admin_config.TenantAdminConfig",   # replaces "django.contrib.admin"
+```
+
+**Why a separate `admin_config.py` and not `admin.py` or `apps.py`?**
+
+`TenantAdminConfig` must live in a module that can be safely imported *before*
+the app registry is ready (Django imports the `AppConfig` class listed in
+`INSTALLED_APPS` during startup, before any models are available).
+
+- `admin.py` imports models at module level → `AppRegistryNotReady` at startup.
+- `apps.py` already defines `TenantsConfig`. Django auto-scans `<module>.apps`
+  for all `AppConfig` subclasses when resolving the `my_package.tenants` entry;
+  finding two configs with `name = "django.contrib.admin"` raises
+  `ImproperlyConfigured: Application labels aren't unique, duplicates: admin`.
+- A dedicated `admin_config.py` that imports only `AdminConfig` (no models)
+  avoids both problems.
+
+---
+
+## Testing
+
+### The public tenant fixture
+
+`TenantMainMiddleware` runs on every request — including test client requests.
+It looks up a `Domain` record matching the request hostname. Without a matching
+record, every view test fails with `Domain.DoesNotExist` for `"testserver"`.
+
+Add an **autouse** fixture that creates the public tenant and its test domains:
+
+```python
+# my_package/tests/fixtures.py
+import pytest
+from my_package.tenants.models import Domain, Tenant
+
+
+@pytest.fixture(autouse=True)
+def _public_tenant(db) -> None:
+    """Create the public tenant and test-server domains for TenantMainMiddleware."""
+    tenant, _ = Tenant.objects.get_or_create(
+        schema_name="public",
+        defaults={"name": "Public"},
+    )
+    for hostname in ("testserver", "localhost"):
+        Domain.objects.get_or_create(
+            domain=hostname,
+            defaults={"tenant": tenant, "is_primary": hostname == "testserver"},
+        )
+```
+
+Creating a `Tenant` with `schema_name="public"` is safe — django-tenants uses
+`CREATE SCHEMA IF NOT EXISTS`, so it is a no-op when the schema already exists.
+
+### ROOT\_URLCONF override
+
+`reverse()` calls outside a request context use `ROOT_URLCONF` (the tenant URL
+conf). If your test assertions call `reverse("index")` or other public-only
+URL names, they will raise `NoReverseMatch` because those names only exist in
+`PUBLIC_SCHEMA_URLCONF`.
+
+Override `ROOT_URLCONF` in your settings fixture so that `reverse()` resolves
+against the public URL conf:
+
+```python
+@pytest.fixture(autouse=True)
+def _settings_overrides(settings, tmp_path) -> None:
+    # ... other overrides ...
+    settings.ROOT_URLCONF = "config.urls.public"
+```
+
+### Schema creation is expensive — avoid per-test creation
+
+When `Tenant.save()` runs with `auto_create_schema = True`, django-tenants
+creates a new PostgreSQL schema and runs **all tenant migrations**. This takes
+3–5 seconds per call. With function-scoped fixtures, that cost multiplies by
+every test that needs a tenant.
+
+**Solution: session-scoped schema, function-scoped rows.**
+
+1. A **session-scoped** `_tenant_schema` fixture creates the tenant schema
+   once (with `--reuse-db`, it persists across runs).
+2. Function-scoped fixtures create lightweight `Tenant` rows with
+   `auto_create_schema = False` — no migrations run.
+
+```python
+TENANT_SCHEMA_NAME = "test_tenant"
+
+# Session-scoped: creates schema + runs migrations once
+@pytest.fixture(scope="session")
+def _tenant_schema(django_db_setup, django_db_blocker):
+    with django_db_blocker.unblock():
+        # Skip if schema already exists (--reuse-db)
+        ...
+        tenant = Tenant(schema_name=TENANT_SCHEMA_NAME, name="Test Tenant")
+        tenant.save()  # creates schema + migrations (~5s, once)
+        Tenant.objects.filter(pk=tenant.pk).delete()  # row only; schema stays
+
+# Function-scoped: cheap row creation, no schema work
+@pytest.fixture
+def current_tenant(db, settings, _tenant_schema):
+    tenant = Tenant(schema_name=TENANT_SCHEMA_NAME, name="Test Tenant")
+    tenant.auto_create_schema = False  # schema already exists
+    tenant.save()
+    ...
+```
+
+### TenantFactory defaults to no schema creation
+
+`TenantFactory` overrides `_create` to set `auto_create_schema = False` by
+default. Pass `with_schema=True` when you genuinely need a new schema (e.g.
+`transactional_db` tests):
+
+```python
+TenantFactory()                      # fast — no schema creation
+TenantFactory(with_schema=True)      # slow — creates schema + runs migrations
+```
+
+### Cross-schema FK constraints and transactional\_db
+
+Django's `TransactionTestCase` flushes tables with `TRUNCATE` **without
+CASCADE** on PostgreSQL. If a tenant schema has FK constraints pointing to
+shared-schema tables, the flush fails with:
+
+```
+cannot truncate a table referenced in a foreign key constraint
+```
+
+**Solution:** Drop cross-schema FK constraints after creating the schema.
+Django validates FKs at the application level, so removing DB-level
+cross-schema FKs doesn't affect test correctness.
+
+Tests using `transactional_db` must also truncate tenant-schema tables in
+their teardown, since `transactional_db`'s flush only covers the public
+schema. Without this, committed data leaks to subsequent tests or runs.
+
+```python
+@pytest.fixture
+def tenant_fixture(transactional_db, settings, _tenant_schema):
+    tenant = Tenant(schema_name=TENANT_SCHEMA_NAME, ...)
+    tenant.auto_create_schema = False
+    tenant.save()
+    ...
+    yield tenant
+    # Truncate tenant tables — transactional_db only flushes public schema
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT tablename FROM pg_tables WHERE schemaname = %s",
+            [TENANT_SCHEMA_NAME],
+        )
+        tables = [row[0] for row in cursor.fetchall()]
+        if tables:
+            qualified = ", ".join(f'"{TENANT_SCHEMA_NAME}"."{t}"' for t in tables)
+            cursor.execute(f"TRUNCATE {qualified} CASCADE")
+```
+
+---
+
+## Gotchas
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `AttributeError: 'Settings' object has no attribute 'TENANT_DOMAIN_MODEL'` | Setting named `DOMAIN_MODEL` instead of `TENANT_DOMAIN_MODEL` | Rename the setting |
+| `ImproperlyConfigured: TENANT_APPS is empty` | `TENANT_APPS = []` | Add at least one app to `TENANT_APPS` |
+| `Domain.DoesNotExist` in tests | No `Domain` record for `"testserver"` | Add the `_public_tenant` autouse fixture |
+| `NoReverseMatch` for public URL names in tests | `ROOT_URLCONF` points to tenant URL conf | Override to `PUBLIC_SCHEMA_URLCONF` in test settings |
+| `connection.tenant` raises `AttributeError` | `TenantMainMiddleware` sets `request.tenant`, not `connection.tenant` | Use `request.tenant` |
+| `No tenant for hostname "localhost"` when hitting `localhost:8000` | `Domain` record stored as `localhost:8000` but django-tenants strips the port before lookup | Store `Domain.domain` without the port — `localhost`, not `localhost:8000` |
+| Admin shows "not available for this type of schema" for a `SHARED_APPS` entry | App listed by module name but registers under a different `AppConfig.label` | Use the full `AppConfig` dotted path (e.g. `"django_tasks_db.apps.TasksAppConfig"`) in `SHARED_APPS` |
+| Tenant subdomain returns 404 in development | `ALLOWED_HOSTS` explicitly set without the `.localhost` wildcard | In `.env` set `ALLOWED_HOSTS=.localhost,127.0.0.1`. The leading dot is Django's wildcard and matches all `*.localhost` subdomains |
+| `AppRegistryNotReady` or `ImproperlyConfigured: duplicates: admin` when wiring a custom `AdminSite` | Putting the `AdminConfig` subclass in `admin.py` (imports models) or `apps.py` (Django auto-scans and finds two configs with the same label) | Put the `AdminConfig` subclass in its own module (e.g. `admin_config.py`) that imports only `AdminConfig` and no models — see [Admin site customisation](#admin-site-customisation) |


### PR DESCRIPTION
Adds four documentation improvements from #327.

**New files:**
- `docs/tenants.md` — multi-tenancy with django-tenants: schema setup, SHARED_APPS/TENANT_APPS rules, URL routing, accessing `request.tenant`, admin customisation, testing patterns (session-scoped schema, public tenant fixture), gotchas table. Project-specific references (`libreworks`) replaced with `my_package`.
- `docs/sse.md` — SSE with psycopg LISTEN/NOTIFY: async view, publishing, HTMX integration. Testing section corrects the prior guidance: `AsyncClient` hangs on streaming views; use `view.__wrapped__` with `AsyncRequestFactory` instead.

**Updated files:**
- `docs/channels.md` — rewritten to cover WebSockets only (SSE is now in `sse.md`). Adds: Daphne local dev server section, `AuthMiddlewareStack` in ASGI config, Alpine `@htmx:ws-after-send` input-clearing tip.
- `AGENTS.md.jinja` — lookup table gains rows for `docs/sse.md` and `docs/tenants.md`; "Channels, SSE, WebSockets" row split into two.
- `docs/htmx.md` — SSE extension row updated to point to `docs/sse.md`.
- `docs/packages.md` — channels entry updated to reference both `channels.md` and `sse.md`.

**No change:** `docs/images.md` — already complete (thumbnail rendering section was added in a prior commit).

Closes #327