### PR TITLE
fix: remove just check-all pre-commit hook from generated settings.json

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -166,16 +166,6 @@ def install_claude_hooks() -> None:
                                 " — fix the pre-commit issue instead.' >&2; exit 2; fi"
                             ),
                         },
-                        {
-                            "type": "command",
-                            "command": (
-                                "CMD=$(jq -r '.tool_input.command');"
-                                " if echo \"$CMD\" | grep -qE 'git commit';"
-                                " then echo 'Running just check-all before commit...' >&2;"
-                                " just check-all >&2 || { echo 'BLOCKED: just check-all failed"
-                                " — fix errors before committing.' >&2; exit 2; }; fi"
-                            ),
-                        },
                     ],
                 },
             ],

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -39,7 +39,7 @@ conftest.py         # Root pytest config (fixture plugins)
 ## Commands
 
 ```bash
-just check-all          # lint → typecheck → manage.py check → test-all — run before committing
+just check-all          # lint → typecheck → manage.py check → test-all — run before opening a PR
 just test               # unit tests with coverage
 just test-e2e           # Playwright E2E tests (headless)
 just serve              # dev server + Tailwind watcher
@@ -74,6 +74,8 @@ Tests live in `{{ package_name }}/**/tests/`; framework: `pytest`+`pytest-django
 Conventional commits enforced by commitlint. Format: `type: subject`
 
 Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+
+Run targeted tests on intermediate commits. Run `just check-all` once before opening a PR — not on every commit.
 
 ## Code Style
 


### PR DESCRIPTION
## Summary

- Removes the `PreToolUse:Bash` hook that ran `just check-all` before every `git commit` in the generated `.claude/settings.json`
- Keeps the `--no-verify` guard (blocks skipping pre-commit hooks)
- Updates `AGENTS.md.jinja` to document that `just check-all` should be run manually before opening a PR, not enforced on every commit

Closes #336