### PR TITLE
docs(dj-remove-slop): Add §9 redirect assertion check

### DIFF
--- a/template/.agents/skills/dj-remove-slop/SKILL.md
+++ b/template/.agents/skills/dj-remove-slop/SKILL.md
@@ -199,6 +199,30 @@ Apply these mechanical fixes:
 
 ---
 
+## 10. Private methods/functions defined before public ones
+
+Private methods and functions (prefixed with `_`) are implementation details.
+They should follow the public interface they support, not precede it. Defining
+private helpers before the public methods that call them forces readers to wade
+through internals before understanding the public API.
+
+```bash
+rg "^\s+def _" --type py
+```
+
+For each class, check whether any `_private` method is defined above a `def`
+method (without the `_` prefix) in the same class body. Flag the offending
+ordering; the fix is to move private methods to after all public methods.
+
+Apply the same rule to module-level functions: a `_helper()` defined above the
+public `do_thing()` that calls it should be moved below it.
+
+**Exception:** `__dunder__` methods are not private in this sense — they belong
+wherever Django/Python convention places them (e.g. `__str__` near the top of
+a model class).
+
+---
+
 ## Report format
 
 Present findings grouped by category before taking any action:
@@ -235,6 +259,10 @@ Redirect assertions (§9)
   orders/tests.py:44    assert response.status_code == 302; assert response["Location"] == "/orders/"
                         → assert response.url == "/orders/"
   orders/tests.py:71    assert response.status_code == 302  (no URL check — flagged only)
+
+Private before public (§10)
+  orders/views.py       OrderView._build_query (line 12) defined before get (line 28) → move below
+  utils/helpers.py      _parse_date (line 3) defined before format_date (line 19) → move below
 ```
 
 After presenting, ask:

--- a/template/.agents/skills/dj-remove-slop/SKILL.md
+++ b/template/.agents/skills/dj-remove-slop/SKILL.md
@@ -174,6 +174,31 @@ is correct and sufficient.
 
 ---
 
+## 9. Low-quality redirect assertions in tests
+
+Redirect assertions written against raw status codes and `response["Location"]`
+are harder to read and more brittle than Django's built-in `response.url`.
+
+```bash
+rg 'status_code\s*==\s*30[0-9]' --type py
+rg 'response\["Location"\]' --type py
+```
+
+Apply these mechanical fixes:
+
+1. `assert response.status_code == 302` + `assert response["Location"] == X`
+   → `assert response.url == X`
+2. `assert response.status_code == 302` + `assert response.url == X` (already present)
+   → drop the now-redundant `status_code` line
+3. `assert response.status_code == 302` + `assert "X" in response["Location"]`
+   → `assert "X" in response.url`
+4. `assert response.status_code == 302` + `assert response["Location"].endswith(X)`
+   → `assert response.url.endswith(X)`
+5. Bare `assert response.status_code == 302` with no URL check
+   → leave unchanged (destination unknown; flagging only)
+
+---
+
 ## Report format
 
 Present findings grouped by category before taking any action:
@@ -205,6 +230,11 @@ Meta.ordering (§7)
 Mutable class constants (§8)
   accounts/forms.py:12  fields = ["name", "email"]       → change to tuple
   reports/models.py:7   ClassVar[list[str]] = [...]       → tuple[str, ...] = (...) (no ClassVar needed for tuples)
+
+Redirect assertions (§9)
+  orders/tests.py:44    assert response.status_code == 302; assert response["Location"] == "/orders/"
+                        → assert response.url == "/orders/"
+  orders/tests.py:71    assert response.status_code == 302  (no URL check — flagged only)
 ```
 
 After presenting, ask:

--- a/template/.agents/skills/dj-remove-slop/references/help.md
+++ b/template/.agents/skills/dj-remove-slop/references/help.md
@@ -14,6 +14,7 @@ making any changes; waits for confirmation before touching anything.
 6. `fields = "__all__"` in ModelForms
 7. `ordering` in `Model.Meta` (implicit ordering on every queryset)
 8. Mutable list literals where tuples should be used (class-level constants)
+9. Low-quality redirect assertions (`status_code == 302` + `response["Location"]`) in tests
 
 **Example:**
 

--- a/template/.agents/skills/dj-remove-slop/references/help.md
+++ b/template/.agents/skills/dj-remove-slop/references/help.md
@@ -15,6 +15,7 @@ making any changes; waits for confirmation before touching anything.
 7. `ordering` in `Model.Meta` (implicit ordering on every queryset)
 8. Mutable list literals where tuples should be used (class-level constants)
 9. Low-quality redirect assertions (`status_code == 302` + `response["Location"]`) in tests
+10. Private methods/functions (`_name`) defined before public ones in the same class or module
 
 **Example:**
 


### PR DESCRIPTION
## Summary

- Adds §9 to `dj-remove-slop/SKILL.md` covering low-quality redirect assertions in tests
- Documents scan commands (`rg 'status_code\s*==\s*30[0-9]'` and `rg 'response["Location"]'`)
- Specifies five mechanical fix rules, including the "leave bare checks alone" rule
- Updates `references/help.md` to list §9 in the check inventory
- Adds a §9 entry to the report format example

Closes #342