### PR TITLE
Add `playwright-install` to initialization steps

### DIFF
--- a/template/justfile
+++ b/template/justfile
@@ -23,6 +23,7 @@ install:
    fi
    just pyinstall
    just precommitinstall
+   just playwright-install
 
 # Update all dependencies
 [group('development')]


### PR DESCRIPTION
Was following the steps after copier and the initial `just check-all` failed because of a missing playwright install.

This fixes it by adding the playwright install to the `install` recipe 

```txt
Your project is ready! Next steps:

  1. Start Docker services
     just start

  2. Install dependencies and set up your environment
     just install

  3. Create and apply the initial database migration
     just dj makemigrations
     just dj migrate

  4. Run all unit and e2e tests, linters and type checks
     just check-all  <-- Fails with `Looks like Playwright was just installed or updated. Please run the following command to download new browsers: playwright install`

  5. Set up the default site
     just dj set_default_site localhost:8000 "megasite"

  6. Create a superuser
     just dj createsuperuser
```

Btw thanks for this project, this is crazy how much it matches my taste, was looking for exactly that and close to build one myself.
Cheers from france