### PR TITLE
feat(dj-deadcode): add scanning scripts and improve vulture false-positive guidance

### DIFF
--- a/template/.agents/skills/dj-deadcode/SKILL.md
+++ b/template/.agents/skills/dj-deadcode/SKILL.md
@@ -29,6 +29,15 @@ before marking it dead — `vulture` has false-positive rates on:
 - Class-based view methods (`get`, `post`, `form_valid`, etc.)
 - Template tag and filter functions registered via `@register`
 - `pytest` fixtures and test helper functions
+- **Pytest fixture arguments** — unused variables in test function signatures
+  are pytest fixtures injected by name for their side effects (e.g.
+  `transactional_db`, `django_db_setup`). They appear unused to vulture but
+  are required for the fixture to run. **Never remove these.**
+- **`TYPE_CHECKING` imports used in `cast()` string annotations** — imports
+  guarded by `if TYPE_CHECKING:` are invisible to vulture at runtime. An
+  import like `from myapp.types import GeopyLocation` used only in
+  `cast("GeopyLocation | None", ...)` will be flagged as unused. Verify
+  with `rg 'GeopyLocation'` before removing.
 
 Exclude any item that is a framework hook unless you can confirm it is never
 called. When in doubt, mark it **uncertain** and surface it to the user rather
@@ -38,29 +47,37 @@ than proposing deletion.
 
 ## 2. Unused URL patterns
 
-Read all `urls.py` files. For each `path()`/`re_path()` entry:
+Run the bundled scanner:
 
-1. Note the `name=` argument.
-2. Search the codebase for `{% url '<name>' %}` in templates and
-   `reverse('<name>')` / `redirect('<name>')` in Python files.
+```bash
+scripts/find-unused-urls.py
+```
 
-Flag any named URL with no references in templates or Python as a candidate
-for removal, along with its corresponding view and template if those are also
-unreferenced.
+It reads all `urls.py` files to collect named URL patterns, then scans every
+`.py` and `.html` file (excluding `.venv`) for `{% url %}`, `reverse()`, and
+`redirect()` references, stripping namespace prefixes before comparing. Any
+pattern with no references is printed.
+
+Flag each result as a candidate for removal together with its view and template
+if those are also unreferenced.
 
 ---
 
 ## 3. Unreferenced templates
 
-List every file under `templates/`. For each template:
+Run the bundled scanner:
 
-1. Search Python files for `render(request, "<path>")`,
-   `get_template("<path>")`, `loader.get_template("<path>")`.
-2. Search templates for `{% include "<path>" %}` and `{% extends "<path>" %}`.
+```bash
+scripts/find-unused-templates.py
+```
 
-Flag any template not found by either search as potentially unused. Exclude
-`base.html` and layout templates (files whose name starts with `_` or
-`base`) — these are typically inherited, not referenced directly.
+It walks every `.html` file under `templates/`, greps the path string across
+all `.py` and `.html` files, and prints any with no hits. Catches all reference
+forms: `TemplateResponse`, `render_to_string`, `{% extends %}`, `{% include %}`,
+`{% fragment %}`, `{% partial "file#name" %}`. Skips `base*.html` and `_*.html`
+automatically.
+
+Flag any template printed by the script as potentially unused.
 
 ---
 

--- a/template/.agents/skills/dj-deadcode/scripts/find-unused-templates.py
+++ b/template/.agents/skills/dj-deadcode/scripts/find-unused-templates.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env -S uv run python
+# ruff: noqa: T201, S603, S607
+"""Print all HTML templates with no references anywhere in the codebase.
+
+Searches .py and .html files for the template path string, catching all
+reference forms: TemplateResponse, render_to_string, render(), {% extends %},
+{% include %}, {% fragment %}, {% partial "file#name" %}, etc.
+
+Skips base/layout templates (basename starts with 'base' or '_') since
+these are extended rather than referenced by name.
+"""
+
+import subprocess
+from pathlib import Path
+
+templates_dir = Path("templates")
+project_dir = Path()
+
+for path in sorted(templates_dir.rglob("*.html")):
+    basename = path.name
+    if basename.startswith(("base", "_")):
+        continue
+    name = str(path.relative_to(templates_dir))
+    result = subprocess.run(
+        [
+            "grep",
+            "-r",
+            "--include=*.html",
+            "--include=*.py",
+            "-l",
+            name,
+            str(project_dir),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    hits = [
+        line
+        for line in result.stdout.splitlines()
+        if Path(line).resolve() != path.resolve()
+    ]
+    if not hits:
+        print(name)

--- a/template/.agents/skills/dj-deadcode/scripts/find-unused-urls.py
+++ b/template/.agents/skills/dj-deadcode/scripts/find-unused-urls.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env -S uv run python
+# ruff: noqa: T201
+"""Print named URL patterns with no references in templates or Python files.
+
+Collects all name=... entries from urls.py files, then scans all .html and
+.py files for {% url 'name' %}, reverse('name'), and redirect('name') usages.
+Reports any name that appears in no reference.
+"""
+
+import re
+from pathlib import Path
+
+
+def is_project_file(path: Path) -> bool:
+    """Return True if path is not inside a dependency directory."""
+    return ".venv" not in path.parts and "node_modules" not in path.parts
+
+
+# Collect all named URL patterns: name -> "file:line"
+url_names: dict[str, str] = {}
+for path in Path().rglob("urls.py"):
+    if not is_project_file(path):
+        continue
+    for i, line in enumerate(path.read_text(errors="ignore").splitlines(), 1):
+        m = re.search(r"name=['\"]([^'\"]+)['\"]", line)
+        if m:
+            url_names[m.group(1)] = f"{path}:{i}"
+
+# Collect all references across templates and Python
+referenced: set[str] = set()
+for pattern in ("**/*.html", "**/*.py"):
+    for path in Path().glob(pattern):
+        if not is_project_file(path):
+            continue
+        try:
+            content = path.read_text(errors="ignore")
+        except OSError:
+            continue
+        # {% url 'name' %} / {% url "name" %} — may be namespaced (e.g. 'projects:dashboard')
+        for ref in re.findall(r"""\{%[-\s]*url\s+['"]([^'"]+)['"]""", content):
+            referenced.add(ref.rsplit(":", 1)[-1])
+        # reverse and redirect calls
+        for ref in re.findall(r"""(?:reverse|redirect)\s*\(\s*['"]([^'"]+)['"]""", content):
+            referenced.add(ref.rsplit(":", 1)[-1])
+
+# Report unreferenced
+for name, loc in sorted(url_names.items()):
+    if name not in referenced:
+        print(f"{name}  ({loc})")


### PR DESCRIPTION
Replace manual per-item grep steps for URL patterns and templates with two
bundled Python scripts that are faster and more thorough.

`scripts/find-unused-templates.py` walks all `.html` files under `templates/`,
greps each path across all `.py` and `.html` files, and prints any with no
hits. Catches all reference forms (`TemplateResponse`, `render_to_string`,
`{% extends %}`, `{% include %}`, `{% fragment %}`, `{% partial "file#name" %}`)
and skips `base*.html` and `_*.html` automatically.

`scripts/find-unused-urls.py` reads all `urls.py` files to collect named URL
patterns, then scans every `.py` and `.html` file for `{% url %}`, `reverse()`,
and `redirect()` references, stripping namespace prefixes before comparing.
Excludes `.venv` and `node_modules`.

Also adds two missing vulture false-positive categories to step 1:

- **Pytest fixture arguments** — unused variables in test function signatures
  are fixtures injected by name for side effects (e.g. `transactional_db`).
  Vulture flags them but they must not be removed.
- **`TYPE_CHECKING` imports in `cast()` string annotations** — imports guarded
  by `if TYPE_CHECKING:` used only in `cast("Type | None", ...)` are invisible
  to vulture at runtime and will be incorrectly flagged as unused.

Closes #350