### PR TITLE
Add `--freeze` option to precommit autoupdate

### DIFF
--- a/template/justfile
+++ b/template/justfile
@@ -141,7 +141,7 @@ precommitinstall:
 # Update pre-commit hooks
 [group('development')]
 precommitupdate:
-   @just precommit autoupdate
+   @just precommit autoupdate --freeze
 
 # Re-run pre-commit on all files
 [group('development')]


### PR DESCRIPTION
This is very similar to what you already have in github actions with pinned sha.

The migration is transparent and the config will automatically be converted to somthing like that:

```yaml
- repo: https://github.com/astral-sh/ruff-pre-commit
    rev: "6fec9b7edb08fd9989088709d864a7826dc74e80"  # frozen: v0.15.12
    hooks:
      - id: ruff-check
        args: ["--fix"]
      - id: ruff-format
```

Also wdyt of adding `precommitall` after `precommitupdate` in the `update` receipe ?
I usually like to do that to see if the hook change causes some regressions or if some part of my code need fixing
I can send another PR if you are interested