### PR TITLE
Replace Searchable mixin with standalone search() function

### DIFF
--- a/template/docs/django-models.md
+++ b/template/docs/django-models.md
@@ -83,39 +83,48 @@ adding the comment.
 
 ## Full-Text Search
 
-Use the `Searchable` mixin from `my_package/db/search.py` for PostgreSQL full-text
-search:
+Use the `search()` function from `my_package/db/search.py` for PostgreSQL full-text
+search. It works with any queryset and defaults to the `search_vector` field:
 
 ```python
-from my_package.db.search import Searchable
+from my_package.db.search import search
 
 
-class ItemQuerySet(Searchable, models.QuerySet):
-    default_search_fields = ("search_vector",)
+# Default — searches search_vector
+search(Item.objects.all(), "django")
 
+# Cross-relation — explicit fields
+search(Message.objects.all(), "django", "search_vector", "sender__search_vector")
 
+# No direct search_vector — explicit fields only
+search(Applicant.objects.all(), "django", "project__search_vector", "user__search_vector")
+```
+
+Models need no mixin or `default_search_fields` attribute — just a `search_vector` field:
+
+```python
 class Item(models.Model):
-    objects = ItemQuerySet.as_manager()
     search_vector = SearchVectorField(null=True)
 ```
 
-Usage:
+In filter classes:
 
 ```python
-Item.objects.search("django")
-Item.objects.search("django", "title", "description")  # override fields
+from my_package.db.search import search
+
+def filter_q(self, queryset, name, value):
+    return search(queryset, value)
 ```
 
 ### Search Vector Updates via Triggers
 
 Maintain `search_vector` via a database trigger rather than `post_save`.
 
-**Important:** the trigger config and the `Searchable.search()` config must
-match. The mixin defaults to `config='simple'`, so the trigger must also use
-`pg_catalog.simple`. Using `pg_catalog.english` in the trigger would apply
-English stemming when building the vector (`"alice"` → `"alic"`) but the query
-would search for the literal token `"alice"`, silently breaking search for many
-common words.
+**Important:** the trigger config and the `search()` config must match. `search()`
+defaults to `config='simple'`, so the trigger must also use `pg_catalog.simple`.
+Using `pg_catalog.english` in the trigger would apply English stemming when building
+the vector (`"alice"` → `"alic"`) but the query would search for the literal token
+`"alice"`, silently breaking search for many common words.
 
 ```python
 # migrations/0002_add_search_trigger.py

--- a/template/{{ package_name }}/db/search.py
+++ b/template/{{ package_name }}/db/search.py
@@ -33,7 +33,7 @@ def search(
     query = SearchQuery(value, search_type=search_type, config=config)
 
     rank = functools.reduce(
-        operator.add,
+        operator.add,  # pyright: ignore[reportArgumentType]
         (SearchRank(F(field), query=query) for field in fields),
     )
 

--- a/template/{{ package_name }}/db/search.py
+++ b/template/{{ package_name }}/db/search.py
@@ -1,53 +1,45 @@
 import functools
 import operator
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TypeVar, cast
 
 from django.contrib.postgres.search import SearchQuery, SearchRank
 from django.db.models import F, Q, QuerySet
 
-if TYPE_CHECKING:
-    Base: TypeAlias = QuerySet
-
-else:
-    Base = object
+_QS = TypeVar("_QS", bound=QuerySet)
 
 
-class Searchable(Base):
-    """Mixin to add PostgreSQL full-text search capabilities to a QuerySet."""
+def search(
+    qs: _QS,
+    value: str,
+    *search_fields: str,
+    annotation: str = "rank",
+    config: str = "simple",
+    search_type: str = "websearch",
+) -> _QS:
+    """Search a queryset using PostgreSQL full-text search.
 
-    default_search_fields: tuple[str, ...] = ()
+    Args:
+        qs: The queryset to search.
+        value: The search query string.
+        search_fields: tsvector fields to search. Defaults to ``("search_vector",)``.
+        annotation: Name for the rank annotation.
+        config: PostgreSQL text search configuration.
+        search_type: Type of search query (websearch, plain, phrase, raw).
+    """
+    if not value:
+        return qs.none()
 
-    def search(
-        self,
-        value: str,
-        *search_fields: str,
-        annotation: str = "rank",
-        config: str = "simple",
-        search_type: str = "websearch",
-    ) -> QuerySet:
-        """Search the queryset using PostgreSQL full-text search.
+    fields = search_fields or ("search_vector",)
+    query = SearchQuery(value, search_type=search_type, config=config)
 
-        Args:
-            value: The search query string.
-            search_fields: Fields to search. Falls back to default_search_fields.
-            annotation: Name for the rank annotation.
-            config: PostgreSQL text search configuration.
-            search_type: Type of search query (websearch, plain, phrase, raw).
-        """
-        if not value:
-            return self.none()
+    rank = functools.reduce(
+        operator.add,
+        (SearchRank(F(field), query=query) for field in fields),
+    )
 
-        search_fields = search_fields if search_fields else self.default_search_fields
-        query = SearchQuery(value, search_type=search_type, config=config)
+    q = functools.reduce(
+        operator.or_,
+        (Q(**{field: query}) for field in fields),
+    )
 
-        rank = functools.reduce(
-            operator.add,  # pyright: ignore[reportArgumentType]
-            (SearchRank(F(field), query=query) for field in search_fields),
-        )
-
-        q = functools.reduce(
-            operator.or_,
-            (Q(**{field: query}) for field in search_fields),
-        )
-
-        return self.annotate(**{annotation: rank}).filter(q)
+    return cast("_QS", qs.annotate(**{annotation: rank}).filter(q))


### PR DESCRIPTION
## Summary

- Replaces `Searchable` QuerySet mixin with a standalone `search()` function in `db/search.py`
- Default search field is `"search_vector"` — models need no mixin or `default_search_fields` attribute
- Cross-relation searches pass explicit field names at the call site
- Updates `docs/django-models.md` to remove `Searchable` mixin docs and document the new `search()` API

Closes #355