### PR TITLE
fix(terraform): configure enp7s0 private network via netplan in cloud-init

### DIFF
--- a/template/terraform/hetzner/templates/cloud_init_agent.tftpl
+++ b/template/terraform/hetzner/templates/cloud_init_agent.tftpl
@@ -17,6 +17,14 @@ packages:
   - apt-transport-https
 
 write_files:
+  - path: /etc/netplan/51-private-network.yaml
+    permissions: "0600"
+    content: |
+      network:
+        version: 2
+        ethernets:
+          enp7s0:
+            dhcp4: true
   - path: /usr/local/bin/k3s-daily-cleanup.sh
     permissions: "0755"
     content: |
@@ -28,6 +36,7 @@ write_files:
     content: "0 2 * * * root /usr/local/bin/k3s-daily-cleanup.sh\n"
 
 runcmd:
+  - netplan apply
   - |
     # Wait for K3s server to be reachable (up to 10 minutes)
     for i in $(seq 1 60); do

--- a/template/terraform/hetzner/templates/cloud_init_database.tftpl
+++ b/template/terraform/hetzner/templates/cloud_init_database.tftpl
@@ -17,6 +17,14 @@ packages:
   - apt-transport-https
 
 write_files:
+  - path: /etc/netplan/51-private-network.yaml
+    permissions: "0600"
+    content: |
+      network:
+        version: 2
+        ethernets:
+          enp7s0:
+            dhcp4: true
   - path: /usr/local/bin/k3s-daily-cleanup.sh
     permissions: "0755"
     content: |
@@ -49,6 +57,7 @@ write_files:
       exit 1
 
 runcmd:
+  - netplan apply
   - |
     # Start volume permission setter in background (volume arrives after cloud-init)
     nohup /usr/local/bin/postgres-volume-perms.sh \

--- a/template/terraform/hetzner/templates/cloud_init_server.tftpl
+++ b/template/terraform/hetzner/templates/cloud_init_server.tftpl
@@ -17,6 +17,14 @@ packages:
   - apt-transport-https
 
 write_files:
+  - path: /etc/netplan/51-private-network.yaml
+    permissions: "0600"
+    content: |
+      network:
+        version: 2
+        ethernets:
+          enp7s0:
+            dhcp4: true
   - path: /usr/local/bin/k3s-daily-cleanup.sh
     permissions: "0755"
     content: |
@@ -28,6 +36,7 @@ write_files:
     content: "0 2 * * * root /usr/local/bin/k3s-daily-cleanup.sh\n"
 
 runcmd:
+  - netplan apply
   - |
     PUBLIC_IP="$(curl -s http://169.254.169.254/hetzner/v1/metadata/public-ipv4)"
     curl -sfL https://get.k3s.io | \


### PR DESCRIPTION
## Summary

- Adds `/etc/netplan/51-private-network.yaml` via `write_files` to all three Hetzner cloud-init templates (`cloud_init_server.tftpl`, `cloud_init_database.tftpl`, `cloud_init_agent.tftpl`)
- Inserts `netplan apply` as the first `runcmd` step so the private interface (`enp7s0`) gets a DHCP address before k3s/Flannel start
- DHCP is used (not static) because Hetzner assigns private IPs via DHCP; a static `/16` mask would bypass the gateway and break inter-node routing

## Test plan

- [ ] `terraform apply` on a fresh Hetzner deploy
- [ ] SSH into each node; confirm `ip addr show enp7s0` shows a 10.x.x.x address
- [ ] Confirm k3s starts cleanly and all nodes join the cluster
- [ ] Confirm Flannel logs show no "failed to find IPv4 address" errors

Closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)