### PR TITLE
docs(tenants): document public tenant initialisation on first deploy

### DIFF
--- a/template/.agents/skills/dj-launch/SKILL.md
+++ b/template/.agents/skills/dj-launch/SKILL.md
@@ -699,6 +699,45 @@ just --yes rkube get pods
 
 If all pods are Running:
 
+### django-tenants initialisation (if applicable)
+
+Check whether django-tenants is installed:
+
+```bash
+grep -q 'django-tenants' pyproject.toml && echo "tenants" || echo "no-tenants"
+```
+
+If django-tenants is present, the public tenant and domain record must be created now or
+the app pods will stay in a 404/crash loop. Get the package name from `.copier-answers.yml`:
+
+```bash
+package_name=$(grep '^package_name:' .copier-answers.yml | awk '{print $2}')
+```
+
+Then seed the public tenant via the worker pod (which is healthy even when app pods are crashing):
+
+```bash
+just --yes rkube exec deployment/django-worker -- python manage.py shell -c "
+from ${package_name}.tenants.models import Tenant, Domain
+t, _ = Tenant.objects.get_or_create(schema_name='public', defaults={'name': 'Public'})
+Domain.objects.get_or_create(domain='<domain>', defaults={'tenant': t, 'is_primary': True})
+"
+```
+
+Tell the user: "Public tenant and domain record created — app pods should now become healthy."
+
+Verify the app pods recover:
+
+```bash
+just --yes rkube get pods
+```
+
+If any app pods are still not Running after the tenant is created, diagnose with logs before continuing.
+
+If django-tenants is not present, skip this section.
+
+### Set default site
+
 If `<site_name>` was provided in Step 4, run:
 ```bash
 just --yes rdj set_default_site <domain> "<site_name>"

--- a/template/docs/tenants.md
+++ b/template/docs/tenants.md
@@ -17,6 +17,7 @@ tables).
 - [Admin site customisation](#admin-site-customisation)
 - [Management commands](#management-commands)
 - [Testing](#testing)
+- [First-deploy initialisation](#first-deploy-initialisation)
 - [Gotchas](#gotchas)
 
 ---
@@ -445,6 +446,42 @@ def tenant_fixture(transactional_db, settings, _tenant_schema):
             qualified = ", ".join(f'"{TENANT_SCHEMA_NAME}"."{t}"' for t in tables)
             cursor.execute(f"TRUNCATE {qualified} CASCADE")
 ```
+
+---
+
+## First-deploy initialisation
+
+After a first production deploy, the app pods will return 404 (or crash) until the
+public tenant and its domain record exist. `TenantMainMiddleware` rejects every request
+that has no matching `Domain` row, so the app is effectively dead until you seed the
+database.
+
+The app pods may not be healthy yet, so run the command via the **worker pod**, which
+does not serve incoming requests:
+
+```bash
+kubectl exec deployment/django-worker -- python manage.py shell -c "
+from my_package.tenants.models import Tenant, Domain
+t, _ = Tenant.objects.get_or_create(schema_name='public', defaults={'name': 'Public'})
+Domain.objects.get_or_create(domain='yourdomain.com', defaults={'tenant': t, 'is_primary': True})
+"
+```
+
+Replace `my_package` with your package name and `yourdomain.com` with your production
+domain. If you use `just`, the remote kubectl wrapper makes this shorter:
+
+```bash
+just --yes rkube exec deployment/django-worker -- python manage.py shell -c "
+from my_package.tenants.models import Tenant, Domain
+t, _ = Tenant.objects.get_or_create(schema_name='public', defaults={'name': 'Public'})
+Domain.objects.get_or_create(domain='yourdomain.com', defaults={'tenant': t, 'is_primary': True})
+"
+```
+
+Once the row exists, the app pods will start responding normally.
+
+> **Gotcha:** If your app uses subdomains, each tenant subdomain also needs a `Domain`
+> record. The public domain is the minimum required to unblock the first deploy.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a new **First-deploy initialisation** section to `docs/tenants.md` explaining why app pods 404/crash until the public `Tenant` and `Domain` rows exist, and providing the `kubectl exec` command to seed them via the worker pod
- Adds the new section to the `docs/tenants.md` table of contents
- Adds a conditional post-deploy step to `dj-launch/SKILL.md` that automatically runs the initialisation when `django-tenants` is detected in `pyproject.toml`, reading `package_name` from `.copier-answers.yml`

## Key design decisions

- The command targets `deployment/django-worker` rather than an app pod because the worker is healthy before the tenant exists; app pods may be in a crash loop at this point
- The `dj-launch` step is conditional (`grep django-tenants pyproject.toml`) so non-tenant projects are unaffected

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)