### PR TITLE
feat(terraform/cloudflare): add wildcard A record for tenant subdomains

### DIFF
--- a/template/terraform/cloudflare/README.md
+++ b/template/terraform/cloudflare/README.md
@@ -4,7 +4,7 @@ Sets up Cloudflare DNS, CDN caching, SSL/TLS, and security settings.
 
 ## What This Configures
 
-- **DNS Records**: A record pointing to your Hetzner server (+ optional Grafana subdomain)
+- **DNS Records**: A record pointing to your Hetzner server (+ optional Grafana subdomain, optional wildcard for tenant subdomains)
 - **CDN**: Caching for static assets
 - **SSL/TLS**: Full SSL mode with automatic HTTPS redirects
 - **Security**: Firewall rules, security headers

--- a/template/terraform/cloudflare/main.tf.jinja
+++ b/template/terraform/cloudflare/main.tf.jinja
@@ -56,6 +56,19 @@ resource "cloudflare_record" "grafana" {
   comment         = "Grafana observability UI - managed by Terraform"
 }
 
+# Optional: Wildcard A record for tenant subdomains (django-tenants)
+resource "cloudflare_record" "wildcard" {
+  count           = var.wildcard_subdomains ? 1 : 0
+  zone_id         = data.cloudflare_zone.domain.id
+  name            = "*"
+  content         = var.server_ip
+  type            = "A"
+  proxied         = true
+  ttl             = 1
+  allow_overwrite = true
+  comment         = "Wildcard - tenant subdomains - managed by Terraform"
+}
+
 # Optional: WWW redirect
 resource "cloudflare_record" "www" {
   count           = var.enable_www_redirect ? 1 : 0

--- a/template/terraform/cloudflare/terraform.tfvars.example.jinja
+++ b/template/terraform/cloudflare/terraform.tfvars.example.jinja
@@ -15,6 +15,9 @@ server_ip = ""
 # Redirect www to main domain
 enable_www_redirect = true
 
+# Wildcard A record for tenant subdomains (enable for django-tenants projects)
+# wildcard_subdomains = true
+
 # Monitor IP from Hetzner Terraform output (leave empty if not using observability)
 # monitor_ip = ""
 

--- a/template/terraform/cloudflare/variables.tf.jinja
+++ b/template/terraform/cloudflare/variables.tf.jinja
@@ -32,6 +32,12 @@ variable "enable_www_redirect" {
   default     = true
 }
 
+variable "wildcard_subdomains" {
+  description = "Create a wildcard A record (*.domain) for tenant subdomains (django-tenants)"
+  type        = bool
+  default     = false
+}
+
 variable "grafana_subdomain" {
   description = "Subdomain for Grafana UI (e.g. 'grafana' → grafana.example.com). Leave empty to skip."
   type        = string


### PR DESCRIPTION
## Summary

- Add `wildcard_subdomains` variable (default `false`) to `variables.tf`
- Gate a wildcard `*` A record on that variable, pointing to `server_ip`, in `main.tf`
- Add commented example to `terraform.tfvars.example`
- Update README to mention the new option

Follows the same `count = var.x ? 1 : 0` pattern used by `enable_www_redirect` and `grafana_subdomain`.

## Test plan

- [ ] `terraform plan` with `wildcard_subdomains = false` — no wildcard record in plan
- [ ] `terraform plan` with `wildcard_subdomains = true` — wildcard `*` A record appears in plan pointing to `server_ip`

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)