### PR TITLE
fix(helm/site): gate IngressRoute host matching on tenants.enabled

### DIFF
--- a/template/helm/site/templates/ingress-route.yaml
+++ b/template/helm/site/templates/ingress-route.yaml
@@ -7,7 +7,7 @@ spec:
   entryPoints:
     - websecure
   routes:
-    - match: Host(`{{ .Values.domain }}`)
+    - match: {{ if .Values.tenants.enabled }}PathPrefix(`/`){{ else }}Host(`{{ .Values.domain }}`){{ end }}
       kind: Rule
       services:
         - name: django

--- a/template/helm/site/values.yaml.jinja
+++ b/template/helm/site/values.yaml.jinja
@@ -74,6 +74,10 @@ resources:
 # Application domain - set in values.secret.yaml
 domain: ""
 
+# Multi-tenancy (django-tenants) - set to true to route all subdomains to Django
+tenants:
+  enabled: false
+
 # Django application settings
 app:
   adminUrl: admin/


### PR DESCRIPTION
## Summary

- Add `tenants.enabled: false` to `values.yaml` (follows the `backup.enabled` / `pgUpgrade.enabled` pattern)
- When `tenants.enabled: true`, use `PathPrefix('/')` so Traefik forwards all subdomains to Django for django-tenants subdomain routing
- When `false` (default), keep the strict `Host()` match on the configured domain

## Test plan

- [ ] `helm template` with default values — match rule renders as `Host('...')`
- [ ] `helm template` with `tenants.enabled: true` — match rule renders as `PathPrefix('/')`

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)