### PR TITLE
fix(terraform/cloudflare): make Mailgun DKIM selector configurable

### DIFF
--- a/template/terraform/cloudflare/main.tf.jinja
+++ b/template/terraform/cloudflare/main.tf.jinja
@@ -113,7 +113,7 @@ resource "cloudflare_record" "mailgun_spf" {
 resource "cloudflare_record" "mailgun_dkim" {
   count           = local.mailgun_dkim_value != "" ? 1 : 0
   zone_id         = data.cloudflare_zone.domain.id
-  name            = "mta._domainkey.${var.mailgun_subdomain}"
+  name            = "${var.mailgun_dkim_selector}._domainkey.${var.mailgun_subdomain}"
   content         = "\"${local.mailgun_dkim_value}\""
   type            = "TXT"
   ttl             = 1

--- a/template/terraform/cloudflare/terraform.tfvars.example.jinja
+++ b/template/terraform/cloudflare/terraform.tfvars.example.jinja
@@ -26,5 +26,6 @@ enable_www_redirect = true
 
 # Mailgun configuration (optional)
 # mailgun_subdomain = "mg"
+# mailgun_dkim_selector = "s1"  # check Mailgun dashboard DNS setup for the correct selector
 # mailgun_dkim_value = "k=rsa; p=..."
 # mailgun_mx_servers = ["mxa.eu.mailgun.org", "mxb.eu.mailgun.org"]

--- a/template/terraform/cloudflare/variables.tf.jinja
+++ b/template/terraform/cloudflare/variables.tf.jinja
@@ -50,6 +50,12 @@ variable "mailgun_subdomain" {
   default     = "mg"
 }
 
+variable "mailgun_dkim_selector" {
+  description = "DKIM selector for Mailgun (shown in Mailgun DNS setup as '<selector>._domainkey')"
+  type        = string
+  default     = "s1"
+}
+
 variable "mailgun_dkim_value" {
   description = "Mailgun DKIM public key (leave empty to skip Mailgun DNS)"
   type        = string


### PR DESCRIPTION
## Summary

- Add `mailgun_dkim_selector` variable (default `"s1"`) to `variables.tf`
- Replace hardcoded `mta` in the DKIM record name with `var.mailgun_dkim_selector`
- Add commented example to `terraform.tfvars.example` with a note to check the Mailgun dashboard

## Test plan

- [ ] `terraform plan` with default values — DKIM record name is `s1._domainkey.mg`
- [ ] `terraform plan` with `mailgun_dkim_selector = "mta"` — DKIM record name is `mta._domainkey.mg`

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)