### PR TITLE
feat: add zizmor and harden GitHub Actions workflows

### DIFF
--- a/template/.github/workflows/build.yml
+++ b/template/.github/workflows/build.yml
@@ -10,7 +10,6 @@ jobs:
   build:
     uses: ./.github/workflows/docker.yml
     needs: checks
-    secrets: inherit # pragma: allowlist secret
     permissions:
       attestations: write
       contents: write

--- a/template/.github/workflows/checks.yml
+++ b/template/.github/workflows/checks.yml
@@ -7,6 +7,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd  # v3
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
@@ -27,6 +29,8 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
         with:
           version: "0.9.8"
@@ -52,6 +56,8 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
         with:
           version: "0.9.8"

--- a/template/.github/workflows/deploy.yml
+++ b/template/.github/workflows/deploy.yml
@@ -4,18 +4,19 @@ on:
   workflow_dispatch:
     branches:
       - main
-permissions:
-  attestations: write
-  contents: write
-  packages: write
-  id-token: write
 jobs:
   checks:
     uses: ./.github/workflows/checks.yml
+    permissions:
+      contents: read
   build:
     uses: ./.github/workflows/docker.yml
     needs: checks
-    secrets: inherit # pragma: allowlist secret
+    permissions:
+      attestations: write
+      contents: write
+      packages: write
+      id-token: write
   deploy:
     runs-on: ubuntu-latest
     needs: build
@@ -27,7 +28,9 @@ jobs:
       KUBECONFIG_FILE: PROJECT_SLUG.yaml
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
       - name: Set up kubectl
         uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede  # v4
       - name: Set up Helm

--- a/template/.github/workflows/docker.yml
+++ b/template/.github/workflows/docker.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Log in to Github Registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
         with:
@@ -61,4 +62,6 @@ jobs:
           push-to-registry: true
       - name: Set image output
         id: set_image
-        run: echo "image=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}" >> "$GITHUB_OUTPUT"
+        env:
+          SHA: ${{ github.sha }}
+        run: echo "image=$REGISTRY/$IMAGE_NAME:$SHA" >> "$GITHUB_OUTPUT"

--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -94,6 +94,10 @@ repos:
     rev: v0.4.5
     hooks:
       - id: pysentry
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.25.2
+    hooks:
+      - id: zizmor
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.105.0
     hooks:


### PR DESCRIPTION
## Summary

- Adds zizmor v1.25.2 pre-commit hook to audit GitHub Actions workflow security
- Removes `secrets: inherit` from `build.yml` and `deploy.yml`
- Adds `persist-credentials: false` to all `actions/checkout` steps
- Replaces overly broad top-level `permissions` block in `deploy.yml` with explicit per-job permissions
- Pins unpinned `actions/checkout@v4` in `deploy.yml` to SHA
- Fixes expression injection risk in `docker.yml` `set_image` step by moving `github.sha` into an env var

Closes #357