### PR TITLE
fix: correct script paths in dj-deadcode SKILL.md

### DIFF
--- a/template/.agents/skills/dj-deadcode/SKILL.md
+++ b/template/.agents/skills/dj-deadcode/SKILL.md
@@ -50,7 +50,7 @@ than proposing deletion.
 Run the bundled scanner:
 
 ```bash
-scripts/find-unused-urls.py
+.agents/skills/dj-deadcode/scripts/find-unused-urls.py
 ```
 
 It reads all `urls.py` files to collect named URL patterns, then scans every
@@ -68,7 +68,7 @@ if those are also unreferenced.
 Run the bundled scanner:
 
 ```bash
-scripts/find-unused-templates.py
+.agents/skills/dj-deadcode/scripts/find-unused-templates.py
 ```
 
 It walks every `.html` file under `templates/`, greps the path string across


### PR DESCRIPTION
## Summary

- Update `scripts/find-unused-urls.py` → `.agents/skills/dj-deadcode/scripts/find-unused-urls.py`
- Update `scripts/find-unused-templates.py` → `.agents/skills/dj-deadcode/scripts/find-unused-templates.py`

Running the commands as documented from the project root failed with "No such file or directory" because the paths didn't reflect where Copier places the skill files.

Closes #385