### PR TITLE
feat: add django-removals as opt-in dev check

### DIFF
--- a/template/.env.example.jinja
+++ b/template/.env.example.jinja
@@ -25,5 +25,7 @@ ADMIN_URL=admin/
 USE_BROWSER_RELOAD=true
 # Enable Django Debug Toolbar (development only)
 USE_DEBUG_TOOLBAR=true
+# Use django-removals to scan for deprecated/removed Django features (development only)
+USE_REMOVALS=true
 # Use watchfiles for reloading (development only)
 USE_WATCHFILES=true

--- a/template/config/settings.py.jinja
+++ b/template/config/settings.py.jinja
@@ -553,6 +553,12 @@ if env.bool("USE_DEBUG_TOOLBAR", default=False):
     # INTERNAL_IPS required for debug toolbar
     INTERNAL_IPS = env.list("INTERNAL_IPS", default=["127.0.0.1"])
 
+# Django removals
+# https://github.com/ambient-innovation/django-removals
+
+if env.bool("USE_REMOVALS", default=False):
+    INSTALLED_APPS += ["django_removals"]
+
 # PROJECT-SPECIFIC SETTINGS
 
 # Cookie used to check user accepts cookies

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -53,6 +53,7 @@ dev = [
   "coverage>=7.14.0",
   "django-browser-reload>=1.21.0",
   "django-debug-toolbar>=6.3.0",
+  "django-removals>=1.2.1",
   "django-watchfiles>=1.4.0",
   "factory-boy>=3.3.3",
   "faker>=40.19.1",


### PR DESCRIPTION
## Summary

- Adds `django-removals>=1.2.1` to the `dev` dependencies in `pyproject.toml`
- Adds `USE_REMOVALS=true` to `.env.example` following the opt-in dev tool pattern
- Adds the `USE_REMOVALS` settings block in `config/settings.py`, placing `django_removals` in `INSTALLED_APPS` when enabled

## Design decisions

- Mirrors the existing opt-in pattern used for `django-debug-toolbar` and `django-browser-reload`
- No extra configuration needed beyond `INSTALLED_APPS` — Django's system check framework picks up `django_removals` checks automatically, so `just dj check` and `just check-all` both benefit

## Testing

- Regenerated project from template, confirmed all three changes render correctly
- `just dj check` reports no issues with `USE_REMOVALS=true`
- Pre-commit passes cleanly (three passes)
- All 112 repo-level tests pass

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)