### PR TITLE
refactor: reduce deployment complexity

### DIFF
--- a/template/.agents/skills/dj-db-restore/references/help.md
+++ b/template/.agents/skills/dj-db-restore/references/help.md
@@ -15,7 +15,7 @@ No arguments — the skill walks you through every step interactively.
 1. Checks that backup credentials are configured in the cluster (`backup-secret`).
 2. Lists available backups from Object Storage and asks you to select one (default: most recent). Offers date filtering.
 3. Asks for confirmation before overwriting the database.
-4. Runs `.agents/skills/dj-db-restore/bin/db-restore.sh <filename>` — suspends CronJobs, scales down app and worker, takes a safety backup, restores in-cluster, scales back up, resumes CronJobs (even if interrupted).
+4. Runs `.agents/skills/dj-db-restore/scripts/db-restore.sh <filename>` — suspends CronJobs, scales down app and worker, takes a safety backup, restores in-cluster, scales back up, resumes CronJobs (even if interrupted).
 5. Runs `just rdj migrate` to verify the restored database is consistent.
 
 **Prerequisites**

--- a/template/.agents/skills/dj-db-restore/scripts/list-backups.sh
+++ b/template/.agents/skills/dj-db-restore/scripts/list-backups.sh
@@ -5,7 +5,7 @@
 # aws-cli pod to list all objects in the backup bucket, sorted by date.
 #
 # Usage:
-#   .agents/skills/dj-db-restore/bin/list-backups.sh
+#   .agents/skills/dj-db-restore/scripts/list-backups.sh
 set -euo pipefail
 
 # Resolve the kubeconfig path the same way the justfile does.

--- a/template/.agents/skills/dj-deploy/SKILL.md
+++ b/template/.agents/skills/dj-deploy/SKILL.md
@@ -54,19 +54,46 @@ If `terraform/hetzner/terraform.tfvars` does not yet exist, tell the user:
 
 ---
 
-## Webapp replica count
+## Topology
 
 Before provisioning infrastructure, ask the user:
 
-> How many webapp instances do you want? (default: 2)
+> How do you want to start?
+>
+> **1. Single node** (recommended) — one cx33 running the app, worker,
+>    PostgreSQL and Redis. ~€15/month. You can split roles onto dedicated
+>    nodes later without touching the Helm chart.
+> **2. Split** — dedicated nodes for database, jobrunner, and webapps.
+>    ~€35/month.
+>
+> (1/2, default: 1)
 
-Accept a positive integer. If the user presses Enter or says "default", use **2**.
+If the user presses Enter or chooses **1**, set:
 
-Save the answer as `<webapp_count>`. This value is used in two places:
-- `webapp_count` in `terraform/hetzner/terraform.tfvars` (number of Hetzner nodes)
-- `replicas` in `helm/site/values.secret.yaml` (number of Kubernetes pods)
+```
+<create_database>  = false
+<create_jobrunner> = false
+<webapp_count>     = 0
+<replicas>         = 1
+```
 
-Both must match so the cluster has enough nodes to schedule the requested replicas.
+If the user chooses **2**, ask how many webapp nodes they want (default 2), then set:
+
+```
+<create_database>  = true
+<create_jobrunner> = true
+<webapp_count>     = <their answer>
+<replicas>         = <their answer>
+```
+
+These values are written to `terraform/hetzner/terraform.tfvars`, except `<replicas>`,
+which goes in `helm/site/values.secret.yaml`.
+
+Tell the user:
+> Starting single-node. See `docs/infrastructure.md` for the scaling path, or run
+> `/dj-scale` when you need more capacity.
+
+(Only say this if they chose option 1.)
 
 ---
 
@@ -188,15 +215,17 @@ If `location` is not already set, ask:
 
 Set `location`.
 
-### 1e. Webapp count
+### 1e. Topology
 
-Set `webapp_count` to `<webapp_count>` (collected earlier). This determines how many
-Hetzner nodes are created for webapp pods.
+Set `create_database`, `create_jobrunner` and `webapp_count` to the values collected
+earlier. These determine which roles get dedicated Hetzner nodes; anything left `false`
+or `0` runs on the server node.
 
 ### 1f. Write terraform.tfvars and apply
 
 Write `terraform/hetzner/terraform.tfvars` with all collected values (including
-`webapp_count` and `create_monitor`), preserving any existing values that were already set.
+`create_database`, `create_jobrunner`, `webapp_count` and `create_monitor`), preserving
+any existing values that were already set.
 
 Then:
 ```bash
@@ -469,9 +498,10 @@ Tell the user these have been generated automatically.
 
 ### Webapp replicas
 
-Set `replicas` to `<webapp_count>` (collected at the start of the wizard). This must
-match the `webapp_count` in `terraform/hetzner/terraform.tfvars` so each replica has
-a dedicated node.
+Set `replicas` to `<replicas>` (collected at the start of the wizard).
+
+Single-node topology uses `1`. In a split topology this must match `webapp_count` in
+`terraform/hetzner/terraform.tfvars` so each replica has a dedicated node.
 
 ### Values from Terraform outputs
 

--- a/template/.agents/skills/dj-deploy/SKILL.md
+++ b/template/.agents/skills/dj-deploy/SKILL.md
@@ -525,10 +525,10 @@ The output must be `/tmp/origin_cert.pem: OK`. If verification fails, re-read th
 from terraform output and write it again — do not proceed until it verifies.
 
 If `terraform/storage/` exists:
-- `secrets.hetznerStorageBucket` ← `just terraform-value storage bucket_name`
-- `secrets.hetznerStorageEndpoint` ← `just terraform-value storage endpoint_url`
-- `secrets.hetznerStorageAccessKey` ← read from `terraform/storage/terraform.tfvars` (do not print)
-- `secrets.hetznerStorageSecretKey` ← read from `terraform/storage/terraform.tfvars` (do not print)
+- `secrets.objectStorageBucket` ← `just terraform-value storage bucket_name`
+- `secrets.objectStorageEndpoint` ← `just terraform-value storage endpoint_url`
+- `secrets.objectStorageAccessKey` ← read from `terraform/storage/terraform.tfvars` (do not print)
+- `secrets.objectStorageSecretKey` ← read from `terraform/storage/terraform.tfvars` (do not print)
 - `secrets.useS3Storage` ← set to `"true"`
 
 ### Domain values

--- a/template/.agents/skills/dj-deploy/SKILL.md
+++ b/template/.agents/skills/dj-deploy/SKILL.md
@@ -87,7 +87,7 @@ If the user chooses **2**, ask how many webapp nodes they want (default 2), then
 ```
 
 These values are written to `terraform/hetzner/terraform.tfvars`, except `<replicas>`,
-which goes in `helm/site/values.secret.yaml`.
+which goes in `helm/site/values.yaml`.
 
 Tell the user:
 > Starting single-node. See `docs/infrastructure.md` for the scaling path, or run
@@ -335,7 +335,7 @@ Ask:
 > Enter your full Mailgun sender domain (e.g. `mg.example.com`):
 
 Save the full sender domain (e.g. `mg.example.com`) for use in Step 4
-(`app.mailgunSenderDomain` in `values.secret.yaml`).
+(`app.mailgunSenderDomain` in `values.yaml`).
 
 Extract the subdomain prefix (everything before the first `.`) and set
 `mailgun_subdomain` in `terraform/cloudflare/terraform.tfvars`. For example,
@@ -461,17 +461,27 @@ just terraform storage apply -auto-approve
 
 ---
 
-## Step 4 — Helm secrets
+## Step 4 — Helm values
+
+There are two files, and it matters which value goes where:
+
+| File | Tracked by git? | Holds |
+| ---- | --------------- | ----- |
+| `helm/site/values.yaml` | **yes — commit your changes** | all non-secret config |
+| `helm/site/values.secret.yaml` | no, gitignored | secrets only (`secrets.*`) |
 
 **Check:** If `helm/site/values.secret.yaml` does not exist, copy it from the example:
 ```bash
 cp helm/site/values.secret.yaml.example helm/site/values.secret.yaml
 ```
 
-Read the current file. For each value below, skip if already set to a non-empty,
-non-`CHANGE_ME` value.
+`values.yaml` already ships with defaults filled in from the answers given when the
+project was generated. Read both files. For each value below, skip if already set to a
+non-empty, non-`CHANGE_ME` value.
 
 ### Auto-generated secrets
+
+→ `values.secret.yaml`
 
 Generate each with `openssl rand -hex 32` if not already set:
 - `secrets.postgresPassword`
@@ -481,10 +491,6 @@ Generate each with `openssl rand -hex 32` if not already set:
 Write each value with an individual comment immediately above it:
 
 ```yaml
-app:
-  # auto-generated — rotate with: /dj-rotate-secrets
-  adminUrl: "<generated-slug>/"
-
 secrets:
   # auto-generated — rotate with: /dj-rotate-secrets
   postgresPassword: "<generated>"
@@ -498,6 +504,8 @@ Tell the user these have been generated automatically.
 
 ### Webapp replicas
 
+→ `values.yaml`
+
 Set `replicas` to `<replicas>` (collected at the start of the wizard).
 
 Single-node topology uses `1`. In a split topology this must match `webapp_count` in
@@ -507,7 +515,10 @@ Single-node topology uses `1`. In a split topology this must match `webapp_count
 
 Fetch automatically — never prompt for these:
 
+→ `values.yaml`
 - `postgres.volumePath` ← `just terraform-value hetzner postgres_volume_mount_path`
+
+→ `values.secret.yaml`
 - `secrets.cloudflare.cert` ← `just terraform-value cloudflare origin_cert_pem`
 - `secrets.cloudflare.key` ← `just terraform-value cloudflare origin_key_pem`
 
@@ -533,30 +544,50 @@ If `terraform/storage/` exists:
 
 ### Domain values
 
-- `domain` ← use the domain confirmed in Step 2
+→ `values.yaml`
+
+These are pre-filled from the `domain` given at project generation. Only change them if
+the domain confirmed in Step 2 differs:
+
+- `domain` ← the domain confirmed in Step 2
 - `app.allowedHosts` ← `.` + domain (e.g. `.my_domain.com`)
 
 ### Image
 
-Set a placeholder for now — `just gh deploy` overrides this with the actual SHA tag via
-`--set image=...`, so the value here does not affect the first deploy:
+→ `values.yaml`
+
+Replace the `CHANGE_ME` owner placeholder. `just gh deploy` overrides this with the
+actual SHA tag via `--set image=...`, so the value here only affects a manual
+`just helm site`:
 - `image` ← `ghcr.io/<github_repo>:main`
+
+### Values already defaulted from the project answers
+
+→ `values.yaml`
+
+`app.admins`, `app.contactEmail`, `app.metaAuthor`, `app.metaDescription` and
+`app.mailgunSenderDomain` are pre-filled from the author, email, description and domain
+given when the project was generated. Show the current values and ask:
+
+> These are set in `helm/site/values.yaml`:
+> - admins: `<value>`
+> - contact email: `<value>`
+> - meta author: `<value>`
+> - meta description: `<value>`
+> - mailgun sender domain: `<value>`
+>
+> Change any of them? (y/n)
+
+If **n**, continue. If **y**, ask which and update only those.
+
+If the user provided a different Mailgun sender domain in Step 2e, set
+`app.mailgunSenderDomain` to that value (e.g. `mg.example.com`).
 
 ### Values requiring user input
 
 For each, only prompt if currently `CHANGE_ME` or empty:
 
-**Admins email** (comma-separated list of Django admin email addresses):
-> Enter admin email address(es), comma-separated (e.g. `you@example.com`):
-
-**Contact email:**
-> Enter the public contact email address:
-
-**Mailgun sender domain** — if the user provided a Mailgun sender domain in Step 2e,
-set `app.mailgunSenderDomain` to the full domain (e.g. `mg.example.com`). If Mailgun
-was not configured in Step 2e, skip.
-
-**Admin URL** — generate a random human-readable slug if the user skips:
+**Admin URL** (→ `values.yaml`) — generate a random human-readable slug if the user skips:
 
 ```bash
 slug=$(.agents/skills/scripts/random-slug.py)
@@ -577,7 +608,8 @@ Tell the user which URL was chosen — they will need this to access Django admi
 
 Save this as `<site_name>` for use in Step 6c.
 
-**Meta author, description, keywords** — prompt for each; the user can type **skip** to leave empty.
+**Meta keywords** (→ `values.yaml`) — comma-separated; the user can type **skip** to
+leave empty. Author and description are already defaulted above.
 
 ### Sentry DSN
 
@@ -600,10 +632,19 @@ If it is empty and the user wants email:
 
 If the user skips, leave it empty — outbound email will not work until this is set.
 
-### Write the file
+### Write the files
 
-Write all values to `helm/site/values.secret.yaml`, preserving any values that were
-already set and were not listed above as needing update.
+Write each value to the file marked above it, preserving any values that were already
+set and were not listed as needing update.
+
+`values.yaml` is tracked by git. Tell the user to review and commit it:
+
+```bash
+git diff helm/site/values.yaml
+```
+
+Never write a `secrets.*` value to `values.yaml`, and never write config to
+`values.secret.yaml` — the split is what keeps the tracked file safe to commit.
 
 ---
 
@@ -616,11 +657,13 @@ just gh-set-secrets
 This pushes `KUBECONFIG_BASE64` and `HELM_VALUES_SECRET` to the GitHub repository secrets.
 Tell the user what was pushed and confirm with `gh secret list`.
 
-> **After the initial deploy:** whenever you change a config value in
-> `values.secret.yaml` (e.g. admin email, feature flag), run `just deploy-config`
-> instead of `just gh-set-secrets` and `just helm site` separately. It pushes the
-> secrets to GitHub **and** applies the updated Helm chart to the cluster in one step,
-> keeping CI and the running cluster in sync.
+> **After the initial deploy:**
+> - Changed a **config** value in `helm/site/values.yaml` (admin email, meta tags,
+>   replicas)? Commit it, then run `just helm site`.
+> - Changed a **secret** in `helm/site/values.secret.yaml`? Run `just deploy-config`
+>   instead of `just gh-set-secrets` and `just helm site` separately. It pushes the
+>   secrets to GitHub **and** applies the updated chart in one step, keeping CI and the
+>   running cluster in sync.
 
 ---
 

--- a/template/.agents/skills/dj-rotate-secrets/SKILL.md
+++ b/template/.agents/skills/dj-rotate-secrets/SKILL.md
@@ -104,8 +104,8 @@ proposed summary (truncated to first 8 chars + `…`).
 |--------------------------|---------------------------|
 | `secrets.mailgunApiKey` | mailgun.com → Sending → Domains → API Keys |
 | `secrets.sentryUrl` | Sentry → Project → Settings → Client Keys → DSN |
-| `secrets.hetznerStorageAccessKey` | Hetzner → Security → S3 credentials |
-| `secrets.hetznerStorageSecretKey` | Hetzner → Security → S3 credentials |
+| `secrets.objectStorageAccessKey` | Hetzner → Security → S3 credentials |
+| `secrets.objectStorageSecretKey` | Hetzner → Security → S3 credentials |
 | `secrets.backupAccessKey` | Hetzner → Security → S3 credentials |
 | `secrets.backupSecretKey` | Hetzner → Security → S3 credentials |
 

--- a/template/.agents/skills/dj-rotate-secrets/SKILL.md
+++ b/template/.agents/skills/dj-rotate-secrets/SKILL.md
@@ -239,7 +239,7 @@ call (`KUBECONFIG` is already exported from step 5a):
 NEW_POSTGRES_PASSWORD="$new_postgres" \
 NEW_REDIS_PASSWORD="$new_redis" \
 NAMESPACE="$namespace" \
-  .agents/skills/dj-rotate-secrets/bin/patch-k8s-secrets.sh
+  .agents/skills/dj-rotate-secrets/scripts/patch-k8s-secrets.sh
 ```
 
 Replace `$namespace` with the Helm release namespace (the same namespace the

--- a/template/.agents/skills/dj-rotate-secrets/SKILL.md
+++ b/template/.agents/skills/dj-rotate-secrets/SKILL.md
@@ -4,6 +4,10 @@ description: Rotate auto-generated and third-party Helm secrets and redeploy
 
 Rotate secrets in `helm/site/values.secret.yaml` and redeploy.
 
+**Note:** `app.adminUrl` is non-secret config and lives in `helm/site/values.yaml`,
+which is tracked by git. Everything else this skill rotates is in
+`helm/site/values.secret.yaml`, which is gitignored.
+
 **IMPORTANT: Execute one sub-step at a time. Wait for user confirmation before proceeding to the next sub-step. Do not batch multiple questions or actions into a single response.**
 
 ## Required reading
@@ -153,16 +157,24 @@ entirely — the observability stack has not been deployed.
 
 ## 5. Apply changes
 
-Write the updated values to `helm/site/values.secret.yaml` (and
-`helm/observability/values.secret.yaml` if Grafana password was changed),
-preserving all other keys unchanged. Each auto-generated value must have its own rotation comment
-immediately above it:
+Write `app.adminUrl` to `helm/site/values.yaml`, and every `secrets.*` value to
+`helm/site/values.secret.yaml` (and `helm/observability/values.secret.yaml` if the
+Grafana password was changed), preserving all other keys unchanged.
+
+`helm/site/values.yaml` is tracked by git — if `adminUrl` was rotated, tell the user to
+commit it.
+
+Each auto-generated value must have its own rotation comment immediately above it:
 
 ```yaml
+# helm/site/values.yaml
 app:
   # auto-generated — rotate with: /dj-rotate-secrets
   adminUrl: "<new-slug>/"
+```
 
+```yaml
+# helm/site/values.secret.yaml
 secrets:
   # auto-generated — rotate with: /dj-rotate-secrets
   postgresPassword: "<new-value>"

--- a/template/.agents/skills/dj-rotate-secrets/scripts/patch-k8s-secrets.sh
+++ b/template/.agents/skills/dj-rotate-secrets/scripts/patch-k8s-secrets.sh
@@ -12,7 +12,7 @@
 #
 # Usage:
 #   NEW_POSTGRES_PASSWORD=... NEW_REDIS_PASSWORD=... NAMESPACE=... \
-#     .agents/skills/dj-rotate-secrets/bin/patch-k8s-secrets.sh
+#     .agents/skills/dj-rotate-secrets/scripts/patch-k8s-secrets.sh
 set -euo pipefail
 
 : "${NEW_POSTGRES_PASSWORD:?NEW_POSTGRES_PASSWORD is required}"

--- a/template/.agents/skills/dj-scale/SKILL.md
+++ b/template/.agents/skills/dj-scale/SKILL.md
@@ -19,12 +19,22 @@ Parse `$ARGUMENTS` as: `[n]` (optional target replica count).
 Read `replicas` from `helm/site/values.secret.yaml` (falls back to
 `helm/site/values.yaml` if the secret file does not exist).
 
-Also read `webapp_count` from `terraform/hetzner/terraform.tfvars` to show the
-current Hetzner node count.
+Also read `webapp_count`, `create_jobrunner` and `create_database` from
+`terraform/hetzner/terraform.tfvars` to determine the current topology.
 
-Display:
+If `webapp_count` is `0`, display:
 
-> **Current deployment:**
+> **Current deployment:** single-node topology
+> - Webapp replicas: `<replicas>` (running on the server node)
+> - Dedicated jobrunner node: `<create_jobrunner>`
+> - Dedicated database node: `<create_database>`
+>
+> All webapp replicas share the server node with PostgreSQL, Redis and the
+> worker. See `docs/infrastructure.md` for the scaling path.
+
+Otherwise display:
+
+> **Current deployment:** split topology
 > - Webapp replicas: `<replicas>`
 > - Hetzner nodes (webapp): `<webapp_count>`
 
@@ -62,6 +72,24 @@ Wait for confirmation. If no, stop.
 ### Step 2 — Check node capacity (scale-up and scale-down)
 
 Read `webapp_count` from `terraform/hetzner/terraform.tfvars`.
+
+**Single-node topology (`webapp_count` is 0):** the webapp shares the server node
+with PostgreSQL, Redis and the worker. Extra replicas on the same box add
+resilience against a pod crash but no extra CPU or memory. If `<n>` > 1, advise:
+
+> You are on the single-node topology, so all `<n>` replicas will run on the
+> server node alongside PostgreSQL, Redis and the worker. That guards against a
+> pod crash but does not add capacity — and each replica requests ~1 GB.
+>
+> To add real capacity, move the webapp to dedicated nodes by setting
+> `webapp_count = <n>` in `terraform/hetzner/terraform.tfvars`
+> (see `docs/infrastructure.md`).
+>
+> Options: [1] add replicas on the server node  [2] provision `<n>` dedicated
+> webapp nodes  [3] cancel
+
+If **2**, set `webapp_count` to `<n>` and follow the scale-up flow below.
+If **3**, stop. If **1**, skip to Step 3.
 
 **Scale-up:** If `<n>` > `webapp_count`, advise:
 

--- a/template/.agents/skills/dj-scale/SKILL.md
+++ b/template/.agents/skills/dj-scale/SKILL.md
@@ -16,8 +16,8 @@ Parse `$ARGUMENTS` as: `[n]` (optional target replica count).
 
 ## No arguments — show current replica count
 
-Read `replicas` from `helm/site/values.secret.yaml` (falls back to
-`helm/site/values.yaml` if the secret file does not exist).
+Read `replicas` from `helm/site/values.yaml` (it is non-secret config, so it lives
+in the git-tracked values file).
 
 Also read `webapp_count`, `create_jobrunner` and `create_database` from
 `terraform/hetzner/terraform.tfvars` to determine the current topology.
@@ -131,14 +131,16 @@ without changing node count (user accepts the ongoing cost).
 
 ### Step 3 — Update replicas
 
-Set `replicas: <n>` in `helm/site/values.secret.yaml`.
+Set `replicas: <n>` in `helm/site/values.yaml`.
 
-If `values.secret.yaml` does not exist, set it in `helm/site/values.yaml` instead.
+That file is tracked by git — remind the user to commit the change.
 
 ### Step 4 — Deploy
 
+`replicas` is non-secret config, so no secrets need pushing to GitHub:
+
 ```bash
-just deploy-config
+just helm site
 ```
 
 ### Step 4b — Deprovision idle nodes (scale-down only)

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -88,7 +88,7 @@ just --yes rdj migrate             # run manage.py on production
 ```
 
 Skills that need kubectl beyond these two recipes should call `kubectl` directly.
-Skill scripts (e.g. `.agents/skills/dj-db-restore/bin/`) handle kubeconfig resolution
+Skill scripts (e.g. `.agents/skills/dj-db-restore/scripts/`) handle kubeconfig resolution
 internally.
 
 Human-invoked commands (typed directly in the terminal) do not need `--yes` — the

--- a/template/docs/database-backups.md
+++ b/template/docs/database-backups.md
@@ -118,7 +118,7 @@ just rkube logs -f job/postgres-backup-test -c upload
 ```
 
 You should see the dump size and "Upload complete". Then verify the file appeared in
-the bucket by running `.agents/skills/dj-db-restore/bin/list-backups.sh`.
+the bucket by running `.agents/skills/dj-db-restore/scripts/list-backups.sh`.
 
 Clean up the test job:
 
@@ -145,13 +145,13 @@ Use `/dj-db-restore` for a guided restore. The steps below are for manual use.
 ### List available backups
 
 ```bash
-.agents/skills/dj-db-restore/bin/list-backups.sh
+.agents/skills/dj-db-restore/scripts/list-backups.sh
 ```
 
 ### Run the restore
 
 ```bash
-.agents/skills/dj-db-restore/bin/db-restore.sh backup-20240103-030000.sql.gz
+.agents/skills/dj-db-restore/scripts/db-restore.sh backup-20240103-030000.sql.gz
 ```
 
 The script handles the full lifecycle: suspend CronJobs, scale down app/worker, safety

--- a/template/docs/deployment.md
+++ b/template/docs/deployment.md
@@ -144,8 +144,12 @@ terraform -chdir=terraform/hetzner output -raw postgres_volume_mount_path
 # e.g. /mnt/HC_Volume_12345678
 ```
 
-Both charts ship resource defaults tuned for the Terraform default server type (`cx23`:
-2 vCPU, 4 GB RAM). If you change `server_type` in `terraform.tfvars`, override the
+Both charts ship resource defaults tuned for the default single-node topology, where every
+workload shares one `cx33` (4 vCPU, 8 GB RAM). Total requests come to roughly 2.6 GB,
+leaving headroom for k3s itself.
+
+If you change `server_type` in `terraform.tfvars`, or split roles onto dedicated nodes
+(see [Topology and scaling](infrastructure.md#topology-and-scaling)), override the
 corresponding resource values in `values.secret.yaml`.
 
 ## CI/CD Pipeline

--- a/template/docs/deployment.md
+++ b/template/docs/deployment.md
@@ -126,7 +126,18 @@ just helm site
 just helm observability
 ```
 
-### Secrets
+### Configuration and secrets
+
+The chart splits its values across two files:
+
+| File | Tracked by git? | Holds |
+| ---- | --------------- | ----- |
+| `helm/site/values.yaml` | **yes** | all non-secret config — domain, image, replicas, admin addresses, meta tags, volume path, resource limits |
+| `helm/site/values.secret.yaml` | no, gitignored | secrets only — every key under `secrets.*` |
+
+`values.yaml` ships with defaults filled in from the answers given when the project was
+generated (domain, author, email, description), so most of it needs no editing. Change a
+value, commit it, and run `just helm site`.
 
 Copy and fill in the secrets file:
 
@@ -134,10 +145,14 @@ Copy and fill in the secrets file:
 cp helm/site/values.secret.yaml.example helm/site/values.secret.yaml
 ```
 
-`values.secret.yaml` is gitignored — never commit it.
+`values.secret.yaml` is gitignored — never commit it. Backing it up is your
+responsibility; store it in a password manager.
 
-The `postgres.volumePath` value must match the Hetzner volume mount path provisioned by
-Terraform:
+Two values in `values.yaml` need a per-deployment edit before the first deploy. Neither
+is secret, so commit them:
+
+- `image` — replace the `CHANGE_ME` owner with your GitHub owner
+- `postgres.volumePath` — the Hetzner volume mount path from Terraform:
 
 ```bash
 terraform -chdir=terraform/hetzner output -raw postgres_volume_mount_path
@@ -149,8 +164,8 @@ workload shares one `cx33` (4 vCPU, 8 GB RAM). Total requests come to roughly 2.
 leaving headroom for k3s itself.
 
 If you change `server_type` in `terraform.tfvars`, or split roles onto dedicated nodes
-(see [Topology and scaling](infrastructure.md#topology-and-scaling)), override the
-corresponding resource values in `values.secret.yaml`.
+(see [Topology and scaling](infrastructure.md#topology-and-scaling)), update the
+corresponding resource values in `values.yaml` and commit them.
 
 ## CI/CD Pipeline
 
@@ -277,7 +292,7 @@ just get-kubeconfig
 
 ### Upgrade PostgreSQL major version
 
-Set the upgrade flags in `helm/site/values.secret.yaml` before running `just helm site`:
+Set the upgrade flags in `helm/site/values.yaml` before running `just helm site`:
 
 ```yaml
 pgUpgrade:

--- a/template/docs/infrastructure.md
+++ b/template/docs/infrastructure.md
@@ -6,6 +6,7 @@ This project deploys to a self-hosted K3s cluster on Hetzner Cloud with Cloudfla
 
 - [Why This Stack](#why-this-stack)
 - [Architecture](#architecture)
+- [Topology and scaling](#topology-and-scaling)
 - [Components](#components)
 - [Deployment](#deployment)
 - [Services](#services)
@@ -41,31 +42,108 @@ Full Kubernetes (kubeadm, EKS, GKE) is operationally heavy for a single develope
 
 ## Architecture
 
+The default topology is a **single k3s node** running everything. Roles are split onto
+dedicated nodes as you grow — see [Topology and scaling](#topology-and-scaling).
+
 ```
-┌─────────────────────────────────────────────────────────┐
-│                     Cloudflare                              │
-│  ┌─────────────┐  ┌─────────────┐  ┌───────────────┐    │
-│  │    DNS      │  │    CDN      │  │    SSL/TLS    │    │
-│  └──────┬──────┘  └──────┬──────┘  └───────┬───────┘    │
-└──────────┼────────────────┼────────────────┼──────────────┘
-           │                │                │
-           ▼                ▼                ▼
-┌─────────────────────────────────────────────────────────┐
-│                   Hetzner Cloud                            │
-│  ┌─────────────────────────────────────────────────┐     │
-│  │                  K3s Cluster                      │     │
-│  │  ┌──────────┐  ┌──────────┐  ┌──────────┐   │     │
-│  │  │  Server 1 │  │  Server 2 │  │  Server 3 │   │     │
-│  │  │ (control) │  │  (worker) │  │  (worker) │   │     │
-│  │  └──────────┘  └──────────┘  └──────────┘   │     │
-│  └─────────────────────────────────────────────────┘     │
-│                                                          │
-│  ┌─────────────┐  ┌─────────────┐                      │
-│  │ PostgreSQL  │  │    Redis    │                      │
-│  │  (volume)   │  │             │                      │
-│  └─────────────┘  └─────────────┘                      │
-└─────────────────────────────────────────────────────────┘
+                       Cloudflare
+              DNS  ·  CDN  ·  SSL/TLS
+                           │
+                           ▼
+┌──────────────────────────────────────────────────┐
+│                  Hetzner Cloud                   │
+│  ┌────────────────────────────────────────────┐  │
+│  │  server node  (k3s control plane, cx33)    │  │
+│  │                                            │  │
+│  │   Traefik ingress                          │  │
+│  │   django-app        [webapp=true]          │  │
+│  │   django-worker     [jobrunner=true]       │  │
+│  │   CronJobs          [jobrunner=true]       │  │
+│  │   PostgreSQL        [database=true] ──┐    │  │
+│  │   Redis             [database=true]   │    │  │
+│  └───────────────────────────────────────┼────┘  │
+│                                          ▼       │
+│                                  ┌──────────────┐│
+│                                  │ Hetzner vol. ││
+│                                  │  (pg data)   ││
+│                                  └──────────────┘│
+└──────────────────────────────────────────────────┘
 ```
+
+## Topology and scaling
+
+### How placement works
+
+Every app workload selects a node with a **boolean label** rather than a role name:
+
+| Workload | `nodeSelector` |
+| -------- | -------------- |
+| `django-app` | `webapp: "true"` |
+| `django-worker`, CronJobs, release job | `jobrunner: "true"` |
+| PostgreSQL, Redis | `database: "true"` |
+
+A node can only carry one `role=` value, but it can carry all three booleans. So the
+single server node is labelled `webapp=true jobrunner=true database=true` and runs
+everything, while a split cluster gives each node exactly one of those labels.
+
+**The Helm chart is byte-for-byte identical in both cases.** Scaling is a Terraform
+change plus a redeploy — you never edit the chart.
+
+Terraform applies each label to the server node unless a dedicated node claims it:
+
+| Variable | Default | When set |
+| -------- | ------- | -------- |
+| `webapp_count` | `0` | `N` dedicated webapp nodes take `webapp=true` |
+| `create_jobrunner` | `false` | dedicated jobrunner node takes `jobrunner=true` |
+| `create_database` | `false` | dedicated database node takes `database=true` |
+| `create_monitor` | `false` | separate observability node (see `/dj-deploy-observe`) |
+
+### The scaling path
+
+Each step is independent — take them in any order, as load demands.
+
+**Stage 1 — single node (default).** One `cx33`. Everything runs on it. ~€13/month.
+
+**Stage 2 — split the database.** PostgreSQL and Redis get their own node:
+
+```hcl
+create_database = true
+```
+
+⚠️ **This moves the Hetzner volume between servers.** Terraform will detach it from the
+server node and reattach it to the new database node, so PostgreSQL is down for the
+duration. Take a backup first (`/dj-db-backup`), and expect a short outage.
+
+**Stage 3 — split the workers.** Background tasks and CronJobs stop competing with web
+requests for CPU:
+
+```hcl
+create_jobrunner = true
+```
+
+**Stage 4 — split the webapps.** Dedicated gunicorn nodes:
+
+```hcl
+webapp_count = 2
+```
+
+Then raise `replicas` in `helm/site/values.secret.yaml` to match, and raise the `app`
+resource requests — a dedicated node has the whole box to itself. Or just run `/dj-scale`.
+
+After any stage: `just terraform hetzner apply`, then `just helm site`.
+
+### Migrating an existing cluster
+
+Clusters provisioned before boolean labels existed have nodes labelled only `role=<name>`,
+so pods will not schedule after upgrading the chart. Relabel the existing nodes once:
+
+```bash
+kubectl label node <webapp-node>    webapp=true
+kubectl label node <jobrunner-node> jobrunner=true
+kubectl label node <database-node>  database=true
+```
+
+New nodes get the labels from cloud-init automatically.
 
 ## Components
 
@@ -363,9 +441,15 @@ OTEL_EXPORTER_OTLP_ENDPOINT = "http://otel-collector:4317"
 
 ## Scaling
 
-1. Edit `terraform/hetzner/terraform.tfvars` (e.g. increase `webapp_count`)
-2. Run `terraform apply` - new nodes join the cluster automatically via cloud-init
-3. Run `just helm site` to apply the updated replica count
+See [Topology and scaling](#topology-and-scaling) for the full path from one node to five.
+
+In brief:
+
+1. Edit `terraform/hetzner/terraform.tfvars` (e.g. set `create_database = true`, or
+   increase `webapp_count`)
+2. Run `just terraform hetzner apply` - new nodes join the cluster automatically via
+   cloud-init and pick up their workload label
+3. Run `just helm site` to reschedule onto them
 
 ## Backup
 
@@ -379,7 +463,15 @@ stored in a dedicated `backup-secret` and are never exposed to the app pods.
 
 ## Cost
 
-- 3x CPX11 servers: ~€15/month
-- Volume: ~€4/month
-- DNS: Free
-- Total: ~€20/month
+Default single-node topology:
+
+| Item | Cost |
+| ---- | ---- |
+| 1x cx33 (4 vCPU, 8 GB) | ~€13/month |
+| 50 GB volume | ~€2/month |
+| DNS (Cloudflare) | Free |
+| **Total** | **~€15/month** |
+
+Each split adds one node. A fully split cluster (server + database + jobrunner +
+2x webapp) runs roughly €35/month; adding the monitor node for the observability stack
+adds one more.

--- a/template/helm/site/templates/cronjobs.yaml
+++ b/template/helm/site/templates/cronjobs.yaml
@@ -18,7 +18,7 @@ spec:
         spec:
           restartPolicy: Never
           nodeSelector:
-            role: jobrunner
+            jobrunner: "true"
           containers:
             - name: django
               image: {{ $.Values.image }}

--- a/template/helm/site/templates/django-deployment.yaml
+++ b/template/helm/site/templates/django-deployment.yaml
@@ -21,7 +21,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       nodeSelector:
-        role: webapp
+        webapp: "true"
       containers:
         - name: django
           image: {{ .Values.image }}

--- a/template/helm/site/templates/django-worker-deployment.yaml
+++ b/template/helm/site/templates/django-worker-deployment.yaml
@@ -21,7 +21,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       nodeSelector:
-        role: jobrunner
+        jobrunner: "true"
       containers:
         - name: django
           image: {{ .Values.image }}

--- a/template/helm/site/templates/postgres-backup-cronjob.yaml
+++ b/template/helm/site/templates/postgres-backup-cronjob.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           restartPolicy: Never
           nodeSelector:
-            role: jobrunner
+            jobrunner: "true"
           initContainers:
             - name: dump
               image: {{ .Values.postgres.image }}

--- a/template/helm/site/templates/postgres-statefulset.yaml
+++ b/template/helm/site/templates/postgres-statefulset.yaml
@@ -14,7 +14,7 @@ spec:
         app: postgres
     spec:
       nodeSelector:
-        role: database
+        database: "true"
       containers:
         - name: postgres
           image: {{ .Values.postgres.image }}

--- a/template/helm/site/templates/postgres-upgrade.yaml
+++ b/template/helm/site/templates/postgres-upgrade.yaml
@@ -42,7 +42,7 @@ spec:
         app: postgres-upgrade
     spec:
       nodeSelector:
-        role: database
+        database: "true"
       containers:
         - name: postgres
           image: {{ .Values.pgUpgrade.newImage }}

--- a/template/helm/site/templates/redis-deployment.yaml
+++ b/template/helm/site/templates/redis-deployment.yaml
@@ -13,7 +13,7 @@ spec:
         app: redis
     spec:
       nodeSelector:
-        role: database
+        database: "true"
       containers:
         - name: redis
           image: {{ .Values.redis.image }}

--- a/template/helm/site/templates/release-job.yaml
+++ b/template/helm/site/templates/release-job.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       restartPolicy: Never
       nodeSelector:
-        role: jobrunner
+        jobrunner: "true"
       containers:
         - name: django-release
           image: {{ .Values.image }}

--- a/template/helm/site/values.secret.yaml.example.jinja
+++ b/template/helm/site/values.secret.yaml.example.jinja
@@ -5,8 +5,10 @@
 postgres:
   volumePath: "CHANGE_ME"
 
-# Number of webapp replicas (must match webapp_count in terraform/hetzner/terraform.tfvars)
-replicas: 2
+# Number of webapp replicas.
+# Single-node topology (the default): leave at 1.
+# Split topology: set to webapp_count from terraform/hetzner/terraform.tfvars.
+replicas: 1
 
 # Public domain name
 domain: "{{ domain }}"

--- a/template/helm/site/values.secret.yaml.example.jinja
+++ b/template/helm/site/values.secret.yaml.example.jinja
@@ -1,35 +1,9 @@
 # Copy this file to values.secret.yaml and fill in all values.
 # values.secret.yaml is gitignored - never commit it.
-
-# From: terraform -chdir=terraform/hetzner output -raw postgres_volume_mount_path
-postgres:
-  volumePath: "CHANGE_ME"
-
-# Number of webapp replicas.
-# Single-node topology (the default): leave at 1.
-# Split topology: set to webapp_count from terraform/hetzner/terraform.tfvars.
-replicas: 1
-
-# Public domain name
-domain: "{{ domain }}"
-
-# Application image (ghcr.io/<github-owner>/<repo-name>:<sha>)
-# The deploy workflow sets this automatically; set manually for first-time 'just helm site'.
-image: "ghcr.io/CHANGE_ME/{{ project_slug }}:main"
-
-app:
-  # URL prefix for Django admin - change from default "admin/" for security
-  adminUrl: "admin/"
-  # Comma-separated list of admin email addresses
-  admins: "CHANGE_ME"
-  # Leading dot matches root domain + all subdomains (e.g. ".example.com")
-  allowedHosts: ".{{ domain }}"
-  contactEmail: "CHANGE_ME"
-  mailgunSenderDomain: "CHANGE_ME"
-  metaAuthor: "CHANGE_ME"
-  metaDescription: "CHANGE_ME"
-  metaKeywords: "CHANGE_ME"
-  secureSslRedirect: true
+#
+# This file holds secrets only. Non-secret configuration (domain, admin
+# addresses, meta tags, image, replicas, volume path) lives in values.yaml,
+# which is committed to git.
 
 secrets:
   postgresPassword: "CHANGE_ME"

--- a/template/helm/site/values.yaml.jinja
+++ b/template/helm/site/values.yaml.jinja
@@ -1,8 +1,10 @@
 # Application image - override with the actual image in values.secret.yaml
 image: ghcr.io/CHANGE_ME/{{ project_slug }}:main
 
-# Number of webapp replicas - override in values.secret.yaml
-replicas: 2
+# Number of webapp replicas - override in values.secret.yaml.
+# Default 1 suits the single-node topology; raise it once you split webapps
+# onto dedicated nodes (see docs/infrastructure.md).
+replicas: 1
 
 # PostgreSQL configuration
 postgres:
@@ -32,23 +34,28 @@ postgres:
 redis:
   image: redis:8.2.2-bookworm
 
-# Resource requests/limits - defaults tuned for cx23 (2 vCPU, 4 GB RAM).
-# Override per-workload in values.secret.yaml if using a different server type.
+# Resource requests/limits - defaults tuned for the single-node topology, where
+# every workload shares one cx33 (4 vCPU, 8 GB RAM). Total requests ~2.6 GB,
+# leaving headroom for k3s itself and for bursts.
+#
+# When you split roles onto dedicated nodes (see docs/infrastructure.md), each
+# workload gets a node to itself and these can be raised - override per-workload
+# in values.secret.yaml.
 resources:
   app:
     requests:
-      memory: 1536Mi
-      cpu: 700m
+      memory: 1024Mi
+      cpu: 400m
     limits:
-      memory: 3072Mi
-      cpu: 1600m
+      memory: 2048Mi
+      cpu: 1500m
   worker:
     requests:
-      memory: 1536Mi
-      cpu: 700m
+      memory: 768Mi
+      cpu: 300m
     limits:
-      memory: 3072Mi
-      cpu: 1600m
+      memory: 1536Mi
+      cpu: 1000m
   cronjob:
     requests:
       memory: 512Mi
@@ -58,11 +65,11 @@ resources:
       cpu: 800m
   postgres:
     requests:
-      memory: 1024Mi
-      cpu: 400m
+      memory: 768Mi
+      cpu: 300m
     limits:
-      memory: 2816Mi
-      cpu: 1600m
+      memory: 2048Mi
+      cpu: 1500m
   redis:
     requests:
       memory: 64Mi

--- a/template/helm/site/values.yaml.jinja
+++ b/template/helm/site/values.yaml.jinja
@@ -1,7 +1,11 @@
-# Application image - override with the actual image in values.secret.yaml
+# This file is committed to git and holds all non-secret configuration.
+# Secrets live in values.secret.yaml, which is gitignored.
+
+# Application image. Replace CHANGE_ME with your GitHub owner, then commit.
+# The deploy workflow overrides this with the built image via --set image=...
 image: ghcr.io/CHANGE_ME/{{ project_slug }}:main
 
-# Number of webapp replicas - override in values.secret.yaml.
+# Number of webapp replicas.
 # Default 1 suits the single-node topology; raise it once you split webapps
 # onto dedicated nodes (see docs/infrastructure.md).
 replicas: 1
@@ -10,7 +14,7 @@ replicas: 1
 postgres:
   image: postgres:18.1-bookworm
   storage: 30Gi
-  # Volume mount path - set in values.secret.yaml from:
+  # Volume mount path. Fill in after provisioning, then commit:
   # terraform -chdir=terraform/hetzner output -raw postgres_volume_mount_path
   volumePath: ""
   args:
@@ -78,8 +82,8 @@ resources:
       memory: 256Mi
       cpu: 200m
 
-# Application domain - set in values.secret.yaml
-domain: ""
+# Application domain
+domain: "{{ domain }}"
 
 # Multi-tenancy (django-tenants) - set to true to route all subdomains to Django
 tenants:
@@ -87,10 +91,14 @@ tenants:
 
 # Django application settings
 app:
+  # URL prefix for the Django admin - change from the default for security.
+  # Rotate with /dj-rotate-secrets.
   adminUrl: admin/
-  admins: ""
-  allowedHosts: "*"
-  contactEmail: ""
+  # Comma-separated list of admin email addresses
+  admins: "{{ author_email }}"
+  # Leading dot matches the root domain and all subdomains
+  allowedHosts: ".{{ domain }}"
+  contactEmail: "{{ author_email }}"
   connPool:
     maxIdle: 120
     maxLifetime: 1800
@@ -100,9 +108,9 @@ app:
     timeout: 20
   cspScriptWhitelist: "*.account.google.com,*.googleapis.com,*.cloudflareinsights.com"
   mailgunApiUrl: https://api.eu.mailgun.net/v3
-  mailgunSenderDomain: ""
-  metaAuthor: ""
-  metaDescription: ""
+  mailgunSenderDomain: "{{ domain }}"
+  metaAuthor: "{{ author }}"
+  metaDescription: "{{ description }}"
   metaKeywords: ""
   secureSslRedirect: true
 

--- a/template/helm/site/values.yaml.jinja
+++ b/template/helm/site/values.yaml.jinja
@@ -142,11 +142,11 @@ secrets:
   pwaSha256Fingerprints: ""
   # Object Storage (use_storage=y) - set in values.secret.yaml to enable
   useS3Storage: "false"
-  hetznerStorageAccessKey: ""
-  hetznerStorageSecretKey: ""
-  hetznerStorageBucket: ""
-  hetznerStorageEndpoint: ""
-  hetznerStorageRegion: "fsn1"
+  objectStorageAccessKey: ""
+  objectStorageSecretKey: ""
+  objectStorageBucket: ""
+  objectStorageEndpoint: ""
+  objectStorageRegion: "fsn1"
   # Database backups (backup.enabled: true) - see docs/database-backups.md
   backupAccessKey: ""
   backupSecretKey: ""

--- a/template/terraform/hetzner/main.tf.jinja
+++ b/template/terraform/hetzner/main.tf.jinja
@@ -20,6 +20,21 @@ locals {
   jobrunner_private_ip = cidrhost(var.subnet_ip_range, 4) # 10.0.0.4
   webapp_private_ips   = [for i in range(var.webapp_count) : cidrhost(var.subnet_ip_range, 5 + i)]
   monitor_private_ip   = cidrhost(var.subnet_ip_range, 10) # 10.0.0.10
+
+  # Workload placement labels.
+  #
+  # App workloads select on a boolean label (webapp/jobrunner/database) rather
+  # than on the node's role, because a node can only carry one role= value but
+  # can carry all three booleans. That keeps the Helm chart identical whether
+  # everything runs on one node or each role has its own.
+  #
+  # Any role without a dedicated node has its label applied to the server node.
+  server_workload_labels = compact([
+    var.webapp_count == 0 ? "webapp=true" : "",
+    var.create_jobrunner ? "" : "jobrunner=true",
+    var.create_database ? "" : "database=true",
+  ])
+  server_node_label_args = join(" ", [for label in local.server_workload_labels : "--node-label=${label}"])
 }
 
 # Private network for internal communication
@@ -196,10 +211,11 @@ resource "hcloud_server" "server" {
   firewall_ids = [hcloud_firewall.server.id]
 
   user_data = templatefile("${path.module}/templates/cloud_init_server.tftpl", {
-    hostname       = "${var.cluster_name}-server"
-    private_ip     = local.server_private_ip
-    k3s_token      = var.k3s_token
-    ssh_public_key = var.ssh_public_key
+    hostname        = "${var.cluster_name}-server"
+    private_ip      = local.server_private_ip
+    k3s_token       = var.k3s_token
+    ssh_public_key  = var.ssh_public_key
+    workload_labels = local.server_node_label_args
   })
 
   labels = {
@@ -225,7 +241,9 @@ resource "hcloud_server" "server" {
 }
 
 # Database node (PostgreSQL + Redis)
+# Optional - when create_database is false these workloads run on the server node.
 resource "hcloud_server" "database" {
+  count        = var.create_database ? 1 : 0
   name         = "${var.cluster_name}-database"
   server_type  = var.database_server_type
   image        = var.server_image
@@ -262,14 +280,18 @@ resource "hcloud_server" "database" {
   }
 }
 
+# The volume follows PostgreSQL: it attaches to the dedicated database node when
+# one exists, otherwise to the server node.
 resource "hcloud_volume_attachment" "postgres_attachment" {
   volume_id = hcloud_volume.postgres.id
-  server_id = hcloud_server.database.id
+  server_id = var.create_database ? hcloud_server.database[0].id : hcloud_server.server.id
   automount = true
 }
 
 # Job runner node (for cron jobs and background workers)
+# Optional - when create_jobrunner is false these workloads run on the server node.
 resource "hcloud_server" "jobrunner" {
+  count        = var.create_jobrunner ? 1 : 0
   name         = "${var.cluster_name}-jobrunner"
   server_type  = var.agent_server_type
   image        = var.server_image
@@ -283,6 +305,7 @@ resource "hcloud_server" "jobrunner" {
     k3s_token         = var.k3s_token
     ssh_public_key    = var.ssh_public_key
     role              = "jobrunner"
+    workload_label    = "--node-label=jobrunner=true"
   })
 
   labels = {
@@ -323,6 +346,7 @@ resource "hcloud_server" "webapp" {
     k3s_token         = var.k3s_token
     ssh_public_key    = var.ssh_public_key
     role              = "webapp"
+    workload_label    = "--node-label=webapp=true"
   })
 
   labels = {
@@ -363,6 +387,7 @@ resource "hcloud_server" "monitor" {
     k3s_token         = var.k3s_token
     ssh_public_key    = var.ssh_public_key
     role              = "monitor"
+    workload_label    = ""
   })
 
   labels = {

--- a/template/terraform/hetzner/outputs.tf.jinja
+++ b/template/terraform/hetzner/outputs.tf.jinja
@@ -9,23 +9,23 @@ output "server_private_ip" {
 }
 
 output "database_public_ip" {
-  description = "Public IPv4 address of the database node"
-  value       = hcloud_server.database.ipv4_address
+  description = "Public IPv4 address of the database node (null when PostgreSQL runs on the server node)"
+  value       = var.create_database ? hcloud_server.database[0].ipv4_address : null
 }
 
 output "database_private_ip" {
-  description = "Private IP address of the database node"
-  value       = local.database_private_ip
+  description = "Private IP address of the database node (null when PostgreSQL runs on the server node)"
+  value       = var.create_database ? local.database_private_ip : null
 }
 
 output "jobrunner_public_ip" {
-  description = "Public IPv4 address of the jobrunner node"
-  value       = hcloud_server.jobrunner.ipv4_address
+  description = "Public IPv4 address of the jobrunner node (null when workers run on the server node)"
+  value       = var.create_jobrunner ? hcloud_server.jobrunner[0].ipv4_address : null
 }
 
 output "jobrunner_private_ip" {
-  description = "Private IP address of the jobrunner node"
-  value       = local.jobrunner_private_ip
+  description = "Private IP address of the jobrunner node (null when workers run on the server node)"
+  value       = var.create_jobrunner ? local.jobrunner_private_ip : null
 }
 
 output "webapp_public_ips" {

--- a/template/terraform/hetzner/templates/cloud_init_agent.tftpl
+++ b/template/terraform/hetzner/templates/cloud_init_agent.tftpl
@@ -53,4 +53,4 @@ runcmd:
       sh -s - agent \
       --node-name=${hostname} \
       --flannel-iface=enp7s0 \
-      --node-label=role=${role}
+      --node-label=role=${role} ${workload_label}

--- a/template/terraform/hetzner/templates/cloud_init_database.tftpl
+++ b/template/terraform/hetzner/templates/cloud_init_database.tftpl
@@ -78,4 +78,4 @@ runcmd:
       sh -s - agent \
       --node-name=${hostname} \
       --flannel-iface=enp7s0 \
-      --node-label=role=database
+      --node-label=role=database --node-label=database=true

--- a/template/terraform/hetzner/templates/cloud_init_server.tftpl
+++ b/template/terraform/hetzner/templates/cloud_init_server.tftpl
@@ -48,7 +48,7 @@ runcmd:
       --advertise-address=${private_ip} \
       --tls-san=${private_ip} \
       --tls-san="$PUBLIC_IP" \
-      --node-label=role=server
+      --node-label=role=server ${workload_labels}
   - |
     # Copy kubeconfig for ubuntu user
     mkdir -p /home/ubuntu/.kube

--- a/template/terraform/hetzner/terraform.tfvars.example.jinja
+++ b/template/terraform/hetzner/terraform.tfvars.example.jinja
@@ -14,19 +14,27 @@ cluster_name = "{{ project_slug }}"
 location = "nbg1"
 
 # Server types (cx11-cpx51, ccx13-ccx63, cax11-cax41)
-server_type          = "cx23"  # k3s control plane + Traefik
-database_server_type = "cx23"  # PostgreSQL + Redis
-agent_server_type    = "cx23"  # Jobrunner + Webapps
+server_type          = "cx33"  # k3s control plane + Traefik (+ all workloads by default)
+database_server_type = "cx23"  # PostgreSQL + Redis, when create_database = true
+agent_server_type    = "cx23"  # Jobrunner + Webapps, when split out
 
-# Number of webapp instances
-webapp_count = 2
+# Topology. The defaults below run everything on the single server node, which
+# is the cheapest way to start. Split roles onto dedicated nodes as you grow -
+# the Helm chart is identical either way. See docs/infrastructure.md.
+#
+#   create_database  = true   # move PostgreSQL + Redis to their own node
+#   create_jobrunner = true   # move workers + CronJobs to their own node
+#   webapp_count     = 2      # move gunicorn to N dedicated nodes
+create_database  = false
+create_jobrunner = false
+webapp_count     = 0
 
 # PostgreSQL volume size in GB
 postgres_volume_size = 50
 
 # Provision a monitor node for the observability stack (Grafana + Prometheus + Loki)
-# Set to false to skip now; run /dj-deploy-observe later to provision it.
-create_monitor = true
+# Run /dj-deploy-observe later to provision it.
+create_monitor = false
 
 # Restrict SSH (22) and K3s API (6443) access to specific IPs.
 # Set to your own IP or VPN exit IP, e.g. ["203.0.113.42/32"]

--- a/template/terraform/hetzner/variables.tf.jinja
+++ b/template/terraform/hetzner/variables.tf.jinja
@@ -46,9 +46,9 @@ variable "server_image" {
 }
 
 variable "server_type" {
-  description = "Server type for k3s server node"
+  description = "Server type for the k3s server node. Defaults to cx33 because in the default single-node topology this node also runs the app, worker, PostgreSQL and Redis. cx23 is enough once those are split onto dedicated nodes."
   type        = string
-  default     = "cx23" # 2 vCPU, 4 GB RAM
+  default     = "cx33" # 4 vCPU, 8 GB RAM
 }
 
 variable "database_server_type" {
@@ -64,9 +64,21 @@ variable "agent_server_type" {
 }
 
 variable "webapp_count" {
-  description = "Number of webapp instances to create"
+  description = "Number of dedicated webapp nodes. 0 (default) runs the webapp on the server node - see docs/infrastructure.md for the scaling path."
   type        = number
-  default     = 2
+  default     = 0
+}
+
+variable "create_database" {
+  description = "Provision a dedicated database node. When false (default) PostgreSQL and Redis run on the server node."
+  type        = bool
+  default     = false
+}
+
+variable "create_jobrunner" {
+  description = "Provision a dedicated jobrunner node. When false (default) workers and CronJobs run on the server node."
+  type        = bool
+  default     = false
 }
 
 variable "postgres_volume_size" {
@@ -90,5 +102,5 @@ variable "admin_ips" {
 variable "create_monitor" {
   description = "Whether to provision the monitor node (Grafana + Prometheus + Loki observability stack)"
   type        = bool
-  default     = true
+  default     = false
 }

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -74,14 +74,15 @@ class TestDomainPrefill:
         assert 'domain = "example.com"' in content
 
     def test_helm_site_values_has_domain(self, output_dir):
+        """domain is non-secret config, so it lives in the git-tracked values.yaml."""
         project = render(output_dir, {**DEFAULT_CONTEXT, "domain": "myapp.example.org"})
-        content = (project / "helm" / "site" / "values.secret.yaml.example").read_text()
+        content = (project / "helm" / "site" / "values.yaml").read_text()
         assert 'domain: "myapp.example.org"' in content
         assert 'allowedHosts: ".myapp.example.org"' in content
 
     def test_helm_site_values_no_change_me_for_domain(self, output_dir):
         project = render(output_dir, {**DEFAULT_CONTEXT, "domain": "myapp.example.org"})
-        content = (project / "helm" / "site" / "values.secret.yaml.example").read_text()
+        content = (project / "helm" / "site" / "values.yaml").read_text()
         lines = {line.strip() for line in content.splitlines()}
         assert not any(
             "CHANGE_ME" in line

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -471,6 +471,32 @@ class TestReferenceIntegrity:
                     missing.append(f"{path.relative_to(project)} -> {ref}")
         assert not missing, "referenced scripts do not exist: " + ", ".join(missing)
 
+    def test_object_storage_keys_match_the_chart(self, project):
+        """templates/secret.yaml reads secrets.objectStorage*, so that is the
+        canonical name - values.yaml must declare the same keys."""
+        secret_tmpl = (
+            project / "helm" / "site" / "templates" / "secret.yaml"
+        ).read_text()
+        values = (project / "helm" / "site" / "values.yaml").read_text()
+        consumed = set(
+            re.findall(r"\.Values\.secrets\.(objectStorage\w+)", secret_tmpl)
+        )
+        assert consumed, "expected secret.yaml to read objectStorage* keys"
+        for key in sorted(consumed):
+            assert f"{key}:" in values, f"values.yaml does not declare {key}"
+
+    def test_no_references_to_the_wrong_object_storage_prefix(self, project):
+        stale = [
+            f"{path.relative_to(project)}:{i}"
+            for path in self._text_files(project)
+            for i, line in enumerate(path.read_text().splitlines(), 1)
+            if "hetznerStorage" in line
+        ]
+        values = project / "helm" / "site" / "values.yaml"
+        if "hetznerStorage" in values.read_text():
+            stale.append(str(values.relative_to(project)))
+        assert not stale, "stale hetznerStorage* references: " + ", ".join(stale)
+
 
 class TestClaudeHooksInstallation:
     """Verify that .claude/ hooks are written by the post-gen hook."""

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -360,6 +360,78 @@ class TestAlwaysIncludedFeatures:
     def test_backup_docs_exist(self, project):
         assert (project / "docs" / "database-backups.md").exists()
 
+    def test_single_node_topology_is_the_default(self, project):
+        content = (
+            project / "terraform" / "hetzner" / "terraform.tfvars.example"
+        ).read_text()
+        assert "create_database  = false" in content
+        assert "create_jobrunner = false" in content
+        assert "webapp_count     = 0" in content
+        assert "create_monitor = false" in content
+
+    def test_hetzner_topology_variables_exist(self, project):
+        content = (project / "terraform" / "hetzner" / "variables.tf").read_text()
+        for name in ("create_database", "create_jobrunner", "webapp_count"):
+            assert f'variable "{name}"' in content
+
+    def test_server_node_type_sized_for_single_node(self, project):
+        content = (project / "terraform" / "hetzner" / "variables.tf").read_text()
+        start = content.index('variable "server_type"')
+        assert '"cx33"' in content[start : content.index("\n}", start)]
+
+    def test_server_node_takes_unclaimed_workload_labels(self, project):
+        content = (project / "terraform" / "hetzner" / "main.tf").read_text()
+        assert "server_workload_labels" in content
+        assert 'var.webapp_count == 0 ? "webapp=true" : ""' in content
+        assert 'var.create_jobrunner ? "" : "jobrunner=true"' in content
+        assert 'var.create_database ? "" : "database=true"' in content
+
+    def test_optional_nodes_are_conditional(self, project):
+        content = (project / "terraform" / "hetzner" / "main.tf").read_text()
+        assert "count        = var.create_database ? 1 : 0" in content
+        assert "count        = var.create_jobrunner ? 1 : 0" in content
+
+    def test_postgres_volume_follows_the_database(self, project):
+        content = (project / "terraform" / "hetzner" / "main.tf").read_text()
+        assert (
+            "server_id = var.create_database "
+            "? hcloud_server.database[0].id : hcloud_server.server.id"
+        ) in content
+
+    def test_cloud_init_emits_workload_labels(self, project):
+        templates = project / "terraform" / "hetzner" / "templates"
+        server = (templates / "cloud_init_server.tftpl").read_text()
+        assert "--node-label=role=server ${workload_labels}" in server
+        agent = (templates / "cloud_init_agent.tftpl").read_text()
+        assert "--node-label=role=${role} ${workload_label}" in agent
+        database = (templates / "cloud_init_database.tftpl").read_text()
+        assert "--node-label=database=true" in database
+
+    def test_workloads_select_boolean_labels_not_roles(self, project):
+        """A node carries one role= but can carry all three booleans, so the
+        chart is identical single-node and split."""
+        expected = {
+            "django-deployment.yaml": 'webapp: "true"',
+            "django-worker-deployment.yaml": 'jobrunner: "true"',
+            "cronjobs.yaml": 'jobrunner: "true"',
+            "release-job.yaml": 'jobrunner: "true"',
+            "postgres-backup-cronjob.yaml": 'jobrunner: "true"',
+            "postgres-statefulset.yaml": 'database: "true"',
+            "postgres-upgrade.yaml": 'database: "true"',
+            "redis-deployment.yaml": 'database: "true"',
+        }
+        for name, selector in expected.items():
+            content = (project / "helm" / "site" / "templates" / name).read_text()
+            assert selector in content, name
+            assert "role: " not in content, name
+
+    def test_single_node_resource_requests_fit_one_cx33(self, project):
+        """~2.6 GB requested of 8 GB, leaving room for k3s itself."""
+        content = (project / "helm" / "site" / "values.yaml").read_text()
+        assert "replicas: 1" in content
+        for request in ("memory: 1024Mi", "memory: 768Mi", "memory: 64Mi"):
+            assert request in content
+
     def test_i18n_and_storage_coexist(self, project):
         settings_content = (project / "config" / "settings.py").read_text()
         assert "S3Boto3Storage" in settings_content

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import py_compile
+import re
 import subprocess
 
 
@@ -438,6 +439,37 @@ class TestAlwaysIncludedFeatures:
         assert "USE_I18N = True" in settings_content
         assert (project / "terraform" / "storage" / "main.tf").exists()
         assert (project / "locale").is_dir()
+
+
+class TestReferenceIntegrity:
+    """Docs and skills must point at files and value keys that actually exist."""
+
+    @staticmethod
+    def _text_files(project):
+        for pattern in ("*.md", "*.sh"):
+            for path in project.rglob(pattern):
+                if ".git" not in path.parts and ".venv" not in path.parts:
+                    yield path
+
+    def test_no_references_to_the_old_bin_script_directory(self, project):
+        """Skill scripts live in scripts/; bin/ is a leftover from the rename."""
+        stale = [
+            f"{path.relative_to(project)}:{i}"
+            for path in self._text_files(project)
+            for i, line in enumerate(path.read_text().splitlines(), 1)
+            if re.search(r"skills/[\w-]+/bin/", line)
+        ]
+        assert not stale, "references to skills/<name>/bin/: " + ", ".join(stale)
+
+    def test_every_referenced_skill_script_exists(self, project):
+        missing = []
+        for path in self._text_files(project):
+            for ref in re.findall(
+                r"\.agents/skills/[\w./-]+\.(?:sh|py)", path.read_text()
+            ):
+                if not (project / ref).exists():
+                    missing.append(f"{path.relative_to(project)} -> {ref}")
+        assert not missing, "referenced scripts do not exist: " + ", ".join(missing)
 
 
 class TestClaudeHooksInstallation:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -485,6 +485,50 @@ class TestReferenceIntegrity:
         for key in sorted(consumed):
             assert f"{key}:" in values, f"values.yaml does not declare {key}"
 
+    def test_secret_values_example_holds_only_secrets(self, project):
+        """values.secret.yaml is gitignored; anything non-secret belongs in
+        values.yaml so it can be committed and tested."""
+        content = (project / "helm" / "site" / "values.secret.yaml.example").read_text()
+        top_level = {
+            line.split(":")[0]
+            for line in content.splitlines()
+            if line and not line.startswith((" ", "#"))
+        }
+        assert top_level == {"secrets"}, f"non-secret top-level keys: {top_level}"
+
+    def test_non_secret_config_defaults_come_from_copier_answers(self, project):
+        values = (project / "helm" / "site" / "values.yaml").read_text()
+        for key, expected in (
+            ("domain", "example.com"),
+            ("allowedHosts", ".example.com"),
+            ("admins", "test@example.com"),
+            ("contactEmail", "test@example.com"),
+            ("mailgunSenderDomain", "example.com"),
+            ("metaAuthor", "Test Author"),
+            ("metaDescription", "A test project"),
+        ):
+            assert f'{key}: "{expected}"' in values, (
+                f"{key} not defaulted in values.yaml"
+            )
+
+    def test_non_secret_config_is_not_in_the_secret_file(self, project):
+        content = (project / "helm" / "site" / "values.secret.yaml.example").read_text()
+        for key in (
+            "domain:",
+            "image:",
+            "replicas:",
+            "volumePath:",
+            "adminUrl:",
+            "admins:",
+            "allowedHosts:",
+            "contactEmail:",
+            "metaAuthor:",
+            "metaDescription:",
+            "mailgunSenderDomain:",
+            "secureSslRedirect:",
+        ):
+            assert key not in content, f"{key} should have moved to values.yaml"
+
     def test_no_references_to_the_wrong_object_storage_prefix(self, project):
         stale = [
             f"{path.relative_to(project)}:{i}"


### PR DESCRIPTION
Reduces the deployment surface a generated project has to carry, without changing platform. Four commits, each independently verified.

## 1. Single-node topology by default (`4b9bc1c`) — **breaking**

Workloads selected nodes with `nodeSelector: role: <name>`. A node can only carry one `role=` value, so every generated project had to provision **five VMs** before it could deploy anything.

Select on independent boolean labels (`webapp`, `jobrunner`, `database`) instead. One node can carry all three, so the server node runs everything by default and roles split onto dedicated nodes as load demands. **The Helm chart is byte-for-byte identical in both cases** — scaling is a Terraform change plus a redeploy, never a chart edit.

- New `create_database` / `create_jobrunner` variables; `webapp_count` defaults to `0`, `create_monitor` to `false`
- Resource requests retuned for one node (~2.6 GB of 8 GB), `server_type` cx23 → cx33
- Default cost: **~€20–25/month across five VMs → ~€15/month on one**
- `docs/infrastructure.md` gains a "Topology and scaling" section documenting stages 1→4

⚠️ **Existing clusters need their nodes relabelled once** — see "Migrating an existing cluster" in `docs/infrastructure.md`.

## 2. Fix broken script references (`8a352df`)

Skill scripts live in `scripts/`, but 8 references still pointed at a `bin/` directory that no longer exists. `/dj-rotate-secrets` failed outright at step 5b and the `/dj-db-restore` commands in the docs were unrunnable — 3 scripts unreachable.

## 3. Fix object storage value names (`c337464`)

`templates/secret.yaml` reads `.Values.secrets.objectStorage*`, but `values.yaml` declared `hetznerStorage*` and `/dj-deploy` wrote those names. Nothing read them — anyone following the wizard got object storage **silently unconfigured**.

## 4. Only secrets in `values.secret.yaml` (`1a93836`)

That file was doing double duty as a config file: 12 non-secret keys lived there because it was the only file not in git. Moved to `values.yaml`, where 8 now default straight from the Copier answers — so they arrive filled in rather than as `CHANGE_ME`, and **`/dj-deploy` drops 6 prompts**.

Secret storage and backup are unchanged and remain the operator's responsibility.

## Verification

Run after every commit, on a freshly regenerated project:

- `terraform fmt` + `terraform validate` — pass
- `pre-commit run --all-files` — clean (auto-formatter churn only, zero lint errors)
- `just typecheck` — 0 errors
- `pytest tests/` — **132 passed**, including 16 new tests
- `helm template` — renders correct nodeSelectors and full config from the split values files

New tests guard each fix: topology labels and conditional nodes, a `TestReferenceIntegrity` class that fails if any doc references a nonexistent skill script, and assertions that the config/secret split holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)