### PR TITLE
feat: add Tailscale support

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Generated projects include `dj-*` Claude Code and OpenCode slash commands for co
 | -------------------------- | ------------------------------------------------------------------------------ |
 | `/dj-deploy`               | Interactive first-deploy wizard: provisions infra, configures secrets, deploys |
 | `/dj-deploy-observe`       | Deploy the observability stack (Grafana + Prometheus + Loki)                   |
+| `/dj-tailscale [cmd]`      | Enable, check or disable Tailscale private networking for the cluster         |
 | `/dj-scale [n]`            | View or change the webapp replica count                                        |
 | `/dj-rotate-secrets`       | Rotate auto-generated and third-party Helm secrets and redeploy                |
 | `/dj-enable-db-backups`    | Enable automated daily PostgreSQL backups to a private Object Storage bucket   |

--- a/template/.agents/skills/dj-deploy/SKILL.md
+++ b/template/.agents/skills/dj-deploy/SKILL.md
@@ -115,6 +115,27 @@ If **n**: tell the user:
 
 ---
 
+## Tailscale (private networking)
+
+Ask the user:
+
+> Do you want to put the cluster on a **Tailscale** tailnet? SSH and the
+> Kubernetes API then travel over WireGuard instead of the public internet,
+> and ports 22 and 6443 can be closed to everyone else. Requires a Tailscale
+> account. (y/n)
+
+If **y**: tell the user to run `/dj-tailscale enable` **after** this wizard
+finishes, and continue. Enabling it now would mean collecting Tailscale
+credentials before the cluster exists, and the firewall must not be locked down
+until `kubectl` has been verified over the tailnet — `/dj-tailscale` sequences
+that correctly.
+
+If **n**: continue. SSH and the Kubernetes API stay reachable over the public
+internet, protected by SSH keys and the K3s token. Mention that
+`/dj-tailscale enable` can retrofit a running cluster later.
+
+---
+
 ## Pre-flight checks
 
 Run all of the following before proceeding. If any fail, tell the user what to install

--- a/template/.agents/skills/dj-tailscale/SKILL.md
+++ b/template/.agents/skills/dj-tailscale/SKILL.md
@@ -1,0 +1,270 @@
+---
+description: Enable, check or disable Tailscale private networking for the cluster
+---
+
+Put the cluster on a Tailscale tailnet so SSH and the Kubernetes API are reachable
+over WireGuard instead of the public internet, then close ports 22 and 6443 to
+everyone else.
+
+**IMPORTANT: Execute one sub-step at a time. Wait for user confirmation before proceeding to the next sub-step. Do not batch multiple questions or actions into a single response.**
+
+## Required reading
+
+- `docs/infrastructure.md`
+- `docs/deployment.md`
+
+---
+
+**Lockout rule — the one that matters.** Never tighten `admin_ips` until you have
+confirmed, in this session, that `kubectl` works over the tailnet. Locking
+`admin_ips` to `100.64.0.0/10` while any node is off the tailnet leaves no way in
+except the Hetzner web console. Verify first, lock second, always.
+
+**Secret handling.** The OAuth client secret goes in
+`terraform/hetzner/terraform.tfvars` (gitignored) or an environment variable.
+Never echo it, never ask the user to paste it into this chat.
+
+**Ports 80 and 443 stay open.** Those carry public web traffic via Cloudflare and
+have nothing to do with administrative access.
+
+Parse `$ARGUMENTS` as: `[enable|status|disable]`. Default to `status`.
+
+---
+
+## status
+
+Read `tailscale_oauth_client_secret` from `terraform/hetzner/terraform.tfvars`
+(presence only — never print it) and `admin_ips` from the same file.
+
+```bash
+just terraform hetzner output tailscale_enabled
+just terraform hetzner output server_tailscale_host
+```
+
+Report:
+
+> **Tailscale:** `<enabled|not enabled>`
+> **API address:** `<MagicDNS name, or public IP if not enabled>`
+> **admin_ips:** `<value>`
+
+If Tailscale is enabled but `admin_ips` is still `["0.0.0.0/0", "::/0"]`, add:
+
+> ⚠️ Tailscale is enabled but SSH (22) and the Kubernetes API (6443) are still
+> open to the internet. Run `/dj-tailscale enable` to finish locking down, or
+> leave as-is if that is deliberate.
+
+Then stop.
+
+---
+
+## enable
+
+### Step 1 — Determine which path applies
+
+Check whether infrastructure already exists:
+
+```bash
+just terraform hetzner output server_public_ip
+```
+
+- **Fails or empty** → *day one*: nothing is provisioned yet. Nodes will join at
+  boot via cloud-init. Go to Step 2, then Step 4.
+- **Returns an IP** → *retrofit*: the cluster is already running. Existing nodes
+  cannot pick this up from cloud-init, because all servers set
+  `lifecycle { ignore_changes = [user_data] }`. Go to Step 2, then Step 3.
+
+Tell the user which path you are taking and why.
+
+### Step 2 — Collect Tailscale settings
+
+Tell the user what to create, then wait:
+
+> **In the Tailscale admin console:**
+>
+> 1. **Tag** — under Access Controls, add `tag:k8s` and `tag:ci` to `tagOwners`.
+> 2. **OAuth client** — Settings → OAuth clients → Generate. Give it the
+>    `auth_keys` **write** scope and both tags above.
+>    Use an OAuth client, **not** an auth key: auth keys expire after at most 90
+>    days, and once expired any node you add later silently fails to join.
+> 3. **Tailnet name** — shown at the top of the admin console, e.g.
+>    `tail1a2b3c.ts.net`.
+>
+> Then open `terraform/hetzner/terraform.tfvars` and set:
+>
+> ```hcl
+> tailscale_oauth_client_secret = "tskey-client-..."
+> tailscale_tailnet             = "tail1a2b3c.ts.net"
+> ```
+>
+> Say **continue** when done.
+
+Re-read the file and confirm both are non-empty. Do not print the secret.
+
+### Step 3 — Retrofit path only: join the running nodes
+
+This installs Tailscale on each existing node and adds the server's MagicDNS name
+to the k3s serving certificate.
+
+Show the user what will happen before running anything:
+
+> This will, on each existing node: install Tailscale and join it to your tailnet.
+> On the server it will also add the MagicDNS name to the k3s TLS certificate,
+> which requires **restarting k3s** — the Kubernetes API is briefly unavailable.
+> Running pods are not affected.
+>
+> Proceed? [y/n]
+
+Show the plan first:
+
+```bash
+TAILSCALE_OAUTH_CLIENT_SECRET="$(grep tailscale_oauth_client_secret terraform/hetzner/terraform.tfvars | cut -d'"' -f2)" \
+TAILSCALE_TAILNET="$(grep tailscale_tailnet terraform/hetzner/terraform.tfvars | cut -d'"' -f2)" \
+  .agents/skills/dj-tailscale/scripts/join-nodes.sh --dry-run
+```
+
+Then run it for real by dropping `--dry-run`.
+
+The script verifies the certificate itself and exits non-zero if the SAN is not
+present after the restart. **If it fails, stop.** Do not continue to Step 5 — tell
+the user kubectl will not work over the tailnet and the firewall must stay open
+until it is resolved.
+
+### Step 4 — Day-one path only: provision
+
+```bash
+just terraform hetzner plan
+```
+
+Show the plan. Ask for confirmation, then:
+
+```bash
+just terraform hetzner apply
+```
+
+Nodes install Tailscale and join during cloud-init. Wait for the apply to finish.
+
+### Step 5 — Point kubectl at the tailnet
+
+```bash
+just get-kubeconfig
+```
+
+This rewrites the API address to the server's MagicDNS name. Confirm the output
+mentions "Tailscale enabled".
+
+### Step 6 — Verify before locking anything
+
+The user must be on the tailnet themselves for this to work.
+
+```bash
+just --yes rkube get nodes
+```
+
+**Every node must be `Ready`.** If this fails for any reason, stop here and report
+it. Do not proceed to Step 7 — the firewall change is what makes a failure
+unrecoverable without the Hetzner console.
+
+### Step 7 — Close the public ports
+
+Only after Step 6 succeeded. Tell the user:
+
+> **Action required:** In `terraform/hetzner/terraform.tfvars`, set:
+>
+> ```hcl
+> admin_ips = ["100.64.0.0/10"]
+> ```
+>
+> This closes SSH (22) and the Kubernetes API (6443) to everything except your
+> tailnet. Ports 80 and 443 stay open for web traffic.
+>
+> Say **continue** when done.
+
+Then:
+
+```bash
+just terraform hetzner plan
+```
+
+Show the plan — it should change firewall rules only, no server replacement. If it
+proposes replacing any server, **stop** and report that; something is wrong.
+
+Then apply, and re-run `just --yes rkube get nodes` to confirm access still works.
+
+### Step 8 — CI
+
+CI reaches the cluster over the tailnet too, so the runner needs its own credentials.
+
+> **Action required:** Add two repository secrets:
+>
+> - `TS_OAUTH_CLIENT_ID`
+> - `TS_OAUTH_SECRET`
+>
+> Use the OAuth client from Step 2 (or a separate one scoped to `tag:ci`).
+>
+> ```bash
+> gh secret set TS_OAUTH_CLIENT_ID
+> gh secret set TS_OAUTH_SECRET
+> ```
+
+The deploy workflow already has a Tailscale step that activates only when
+`TS_OAUTH_CLIENT_ID` is set, so no workflow edit is needed.
+
+Then push the updated kubeconfig, which now points at the MagicDNS name:
+
+```bash
+just gh-set-secrets
+```
+
+Finally, tell the user to run a deploy and confirm it succeeds.
+
+---
+
+## disable
+
+**Order matters — reopen the firewall first, or you lock yourself out.**
+
+### Step 1 — Reopen public access
+
+> **Action required:** In `terraform/hetzner/terraform.tfvars`, set:
+>
+> ```hcl
+> admin_ips = ["0.0.0.0/0", "::/0"]
+> ```
+>
+> (Or your own IP, if you have a static one.) Say **continue** when done.
+
+```bash
+just terraform hetzner apply
+```
+
+### Step 2 — Confirm public access works
+
+```bash
+just get-kubeconfig
+just --yes rkube get nodes
+```
+
+The kubeconfig now points at the public IP again. Do not continue until this works.
+
+### Step 3 — Remove Tailscale
+
+> **Action required:** Clear `tailscale_oauth_client_secret` in
+> `terraform/hetzner/terraform.tfvars`. Say **continue** when done.
+
+New nodes will no longer join the tailnet. Existing nodes stay joined until you
+run `sudo tailscale logout` on each — tell the user this, and that the k3s TLS SAN
+drop-in at `/etc/rancher/k3s/config.yaml.d/10-tailscale.yaml` is harmless to leave.
+
+Finally, remove `TS_OAUTH_CLIENT_ID` and `TS_OAUTH_SECRET` from the repository
+secrets so the CI step stops running.
+
+---
+
+## User-facing outputs
+
+| Value | Why the user needs it |
+|-------|----------------------|
+| Which path (day one vs retrofit) | Sets expectations about the k3s restart |
+| `kubectl get nodes` result before locking | The gate on the firewall change |
+| MagicDNS API address | Confirms kubectl traffic is on the tailnet |
+| Reminder that they must be on the tailnet | Otherwise every later command fails confusingly |

--- a/template/.agents/skills/dj-tailscale/references/help.md
+++ b/template/.agents/skills/dj-tailscale/references/help.md
@@ -1,0 +1,55 @@
+**/dj-tailscale [enable|status|disable]**
+
+Put the cluster on a Tailscale tailnet so SSH and the Kubernetes API travel over
+WireGuard instead of the public internet, then close ports 22 and 6443 to
+everything else. Ports 80 and 443 stay open — that is public web traffic via
+Cloudflare.
+
+**Arguments**
+
+| Argument | What it does |
+|----------|--------------|
+| `status` (default) | Reports whether Tailscale is enabled, the current API address, and whether `admin_ips` is still open |
+| `enable` | Sets Tailscale up end to end, detecting whether this is a fresh deploy or an existing cluster |
+| `disable` | Reopens the firewall first, verifies public access, then removes Tailscale |
+
+**What `enable` does**
+
+It picks one of two paths automatically:
+
+- **Day one** — no infrastructure yet. Nodes install Tailscale and join during
+  cloud-init, and the k3s certificate gets the server's MagicDNS name at install
+  time.
+- **Retrofit** — the cluster is already running. Existing nodes cannot pick this
+  up from cloud-init, so the skill runs
+  `.agents/skills/dj-tailscale/scripts/join-nodes.sh` over SSH instead. On the
+  server it also adds the MagicDNS name to the k3s serving certificate, which
+  requires **restarting k3s** — the API is briefly unavailable, running pods are
+  not affected.
+
+Either way it then repoints the kubeconfig at the tailnet, verifies
+`kubectl get nodes` works, and only then closes the public ports.
+
+**Before you start**
+
+In the Tailscale admin console you need:
+
+1. `tag:k8s` and `tag:ci` added to `tagOwners` under Access Controls
+2. An **OAuth client** with the `auth_keys` write scope and both tags —
+   not an auth key, which expires after at most 90 days and would silently
+   break any node added later
+3. Your tailnet name, e.g. `tail1a2b3c.ts.net`
+
+**Examples**
+
+```bash
+/dj-tailscale                 # is it on, and is the firewall still open?
+/dj-tailscale enable          # set it up, or retrofit a running cluster
+/dj-tailscale disable         # unwind it safely
+```
+
+**Safety**
+
+The skill never tightens `admin_ips` until `kubectl get nodes` has succeeded over
+the tailnet in that same session. If verification fails it stops and leaves the
+firewall open. Recovery from a lockout is via the Hetzner web console.

--- a/template/.agents/skills/dj-tailscale/scripts/join-nodes.sh
+++ b/template/.agents/skills/dj-tailscale/scripts/join-nodes.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Join already-running nodes to a tailnet.
+#
+# Nodes created *after* Tailscale is enabled join automatically via cloud-init.
+# This script covers the two cases cloud-init cannot:
+#
+#   1. Retrofitting a cluster provisioned before Tailscale was enabled.
+#   2. Recovering a node where the cloud-init Tailscale step failed.
+#
+# On the server it additionally adds the MagicDNS name to the k3s serving
+# certificate. That is not optional: the existing certificate only carries the
+# private and public IPs, so kubectl over Tailscale would fail verification.
+#
+# Usage:
+#   TAILSCALE_OAUTH_CLIENT_SECRET=tskey-client-... \
+#   TAILSCALE_TAILNET=tail1a2b3c.ts.net \
+#     .agents/skills/dj-tailscale/scripts/join-nodes.sh [--dry-run]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+TF_DIR="$REPO_ROOT/terraform/hetzner"
+
+: "${TAILSCALE_OAUTH_CLIENT_SECRET:?set TAILSCALE_OAUTH_CLIENT_SECRET (tskey-client-...)}"
+: "${TAILSCALE_TAILNET:?set TAILSCALE_TAILNET (e.g. tail1a2b3c.ts.net)}"
+TAILSCALE_TAG="${TAILSCALE_TAG:-tag:k8s}"
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+if [[ ! -d "$TF_DIR" ]]; then
+    echo "Error: $TF_DIR not found" >&2
+    exit 1
+fi
+
+# Node name -> public IP, derived from Terraform outputs so the hostnames match
+# exactly what cloud-init would set on a freshly created node.
+nodes() {
+    (cd "$TF_DIR" && terraform output -json) | python3 -c '
+import json, sys
+
+out = json.load(sys.stdin)
+value = lambda key: (out.get(key) or {}).get("value")
+
+prefix = value("tailscale_name_prefix")
+if not prefix:
+    sys.exit("Error: terraform output tailscale_name_prefix is empty; run terraform apply first")
+
+rows = []
+for key, suffix in (
+    ("server_public_ip", "server"),
+    ("database_public_ip", "database"),
+    ("jobrunner_public_ip", "jobrunner"),
+    ("monitor_public_ip", "monitor"),
+):
+    if value(key):
+        rows.append((f"{prefix}-{suffix}", value(key)))
+
+for index, ip in enumerate(value("webapp_public_ips") or [], start=1):
+    rows.append((f"{prefix}-webapp-{index}", ip))
+
+for name, ip in rows:
+    print(name, ip)
+'
+}
+
+join_node() {
+    local name="$1" ip="$2"
+    echo "==> $name ($ip)"
+
+    if [[ "$DRY_RUN" == true ]]; then
+        echo "    [dry-run] would install Tailscale and join as $name"
+        return 0
+    fi
+
+    # The key goes over stdin and into a 0600 file rather than the command
+    # line, so it never appears in the remote process list.
+    printf '%s?preauthorized=true&ephemeral=false' "$TAILSCALE_OAUTH_CLIENT_SECRET" \
+        | ssh -o StrictHostKeyChecking=accept-new "ubuntu@$ip" \
+            "sudo install -m 600 /dev/stdin /run/tailscale-authkey"
+
+    ssh -o StrictHostKeyChecking=accept-new "ubuntu@$ip" \
+        "sudo TS_TAG='$TAILSCALE_TAG' TS_NAME='$name' bash -s" <<'REMOTE'
+set -euo pipefail
+if ! command -v tailscale >/dev/null 2>&1; then
+    curl -fsSL https://tailscale.com/install.sh | sh
+fi
+tailscale up \
+    --auth-key="file:/run/tailscale-authkey" \
+    --advertise-tags="$TS_TAG" \
+    --hostname="$TS_NAME" \
+    --ssh
+rm -f /run/tailscale-authkey
+tailscale status --self --peers=false || true
+REMOTE
+}
+
+# Add the server's MagicDNS name to the k3s serving certificate.
+#
+# k3s merges every file in config.yaml.d, so this drops a new fragment in
+# rather than rewriting a config file that may already have content. The
+# serving certificate is generated once and cached in dynamic-cert.json;
+# removing it makes k3s regenerate with the current SAN list on restart.
+add_server_tls_san() {
+    local ip="$1" san="$2"
+    echo "==> adding TLS SAN $san to k3s"
+
+    if [[ "$DRY_RUN" == true ]]; then
+        echo "    [dry-run] would add SAN and restart k3s"
+        return 0
+    fi
+
+    ssh -o StrictHostKeyChecking=accept-new "ubuntu@$ip" \
+        "sudo SAN='$san' bash -s" <<'REMOTE'
+set -euo pipefail
+
+if openssl s_client -connect 127.0.0.1:6443 </dev/null 2>/dev/null \
+    | openssl x509 -noout -text 2>/dev/null | grep -q "$SAN"; then
+    echo "SAN already present - nothing to do"
+    exit 0
+fi
+
+mkdir -p /etc/rancher/k3s/config.yaml.d
+cat > /etc/rancher/k3s/config.yaml.d/10-tailscale.yaml <<EOF
+tls-san:
+  - $SAN
+EOF
+
+rm -f /var/lib/rancher/k3s/server/tls/dynamic-cert.json
+echo "restarting k3s (API briefly unavailable; running workloads unaffected)"
+systemctl restart k3s
+
+for _ in $(seq 1 36); do
+    if openssl s_client -connect 127.0.0.1:6443 </dev/null 2>/dev/null \
+        | openssl x509 -noout -text 2>/dev/null | grep -q "$SAN"; then
+        echo "SAN confirmed in serving certificate"
+        exit 0
+    fi
+    sleep 5
+done
+
+echo "ERROR: $SAN is still not in the serving certificate after 3 minutes." >&2
+echo "       The drop-in is at /etc/rancher/k3s/config.yaml.d/10-tailscale.yaml." >&2
+echo "       Do NOT lock admin_ips to the tailnet - kubectl will not connect." >&2
+exit 1
+REMOTE
+}
+
+SERVER_NAME=""
+SERVER_IP=""
+
+while read -r name ip; do
+    [[ -z "$name" ]] && continue
+    join_node "$name" "$ip"
+    if [[ "$name" == *-server ]]; then
+        SERVER_NAME="$name"
+        SERVER_IP="$ip"
+    fi
+done < <(nodes)
+
+if [[ -z "$SERVER_IP" ]]; then
+    echo "Error: no server node found in Terraform outputs" >&2
+    exit 1
+fi
+
+add_server_tls_san "$SERVER_IP" "$SERVER_NAME.$TAILSCALE_TAILNET"
+
+echo
+echo "All nodes joined. Next:"
+echo "  1. just get-kubeconfig     # rewrites the API address to the tailnet"
+echo "  2. just --yes rkube get nodes"
+echo "  3. Only once that works, set admin_ips = [\"100.64.0.0/10\"] and apply."

--- a/template/.github/workflows/deploy.yml
+++ b/template/.github/workflows/deploy.yml
@@ -35,6 +35,17 @@ jobs:
         uses: azure/setup-kubectl@776406bce94f63e41d621b960d78ee25c8b76ede  # v4
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4
+      # Only runs when Tailscale is configured. With it enabled the kubeconfig
+      # points at the server's MagicDNS name, so the runner has to be on the
+      # tailnet before helm can reach the cluster. The node is ephemeral and
+      # tagged, so runners do not accumulate in the device list.
+      - name: Connect to Tailscale
+        if: ${{ secrets.TS_OAUTH_CLIENT_ID != '' }}
+        uses: tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888  # v4.1.3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
       - name: Write kubeconfig
         env:
           KUBECONFIG_BASE64: ${{ secrets.KUBECONFIG_BASE64 }}

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -252,6 +252,7 @@ Available in Claude Code and OpenCode as `/dj-<command>`.
 | ------- | ------- |
 | `/dj-deploy` | Interactive first-deploy wizard (infra → secrets → deploy) |
 | `/dj-deploy-observe` | Deploy the observability stack (Grafana + Prometheus + Loki) |
+| `/dj-tailscale [enable\|status\|disable]` | Enable, check or disable Tailscale private networking |
 | `/dj-scale [n]` | View or change the webapp replica count |
 | `/dj-rotate-secrets` | Rotate auto-generated and third-party Helm secrets and redeploy |
 | `/dj-enable-db-backups` | Enable automated daily PostgreSQL backups to Object Storage |

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -101,6 +101,7 @@ Available in Claude Code and OpenCode as `/dj-<command>`:
 | -------------------------- | ------------------------------------------------------------------------------ |
 | `/dj-deploy`               | Interactive first-deploy wizard: provisions infra, configures secrets, deploys |
 | `/dj-deploy-observe`       | Deploy the observability stack (Grafana + Prometheus + Loki)                   |
+| `/dj-tailscale [cmd]`      | Enable, check or disable Tailscale private networking for the cluster         |
 | `/dj-scale [n]`            | View or change the webapp replica count                                        |
 | `/dj-rotate-secrets`       | Rotate auto-generated and third-party Helm secrets and redeploy                |
 | `/dj-enable-db-backups`    | Enable automated daily PostgreSQL backups to a private Object Storage bucket   |

--- a/template/docs/deployment.md
+++ b/template/docs/deployment.md
@@ -175,9 +175,23 @@ The `deploy` GitHub Actions workflow:
 2. Builds and pushes Docker image (`docker.yml`)
 3. Runs `helm upgrade --rollback-on-failure` with the new image
 
+### Tailscale
+
+If Tailscale is enabled (see
+[Tailscale](infrastructure.md#tailscale-recommended-for-stricter-access-control-or-team-use)),
+`just get-kubeconfig` writes the server's MagicDNS name as the API address rather than
+its public IP. Two consequences:
+
+- **You must be on the tailnet** for `just helm site`, `just rkube` and `just rdj` to work.
+- **CI must join the tailnet too.** Set `TS_OAUTH_CLIENT_ID` and `TS_OAUTH_SECRET` as
+  repository secrets; the deploy workflow's Tailscale step activates automatically when
+  they are present. Re-run `just gh-set-secrets` afterwards so `KUBECONFIG_BASE64`
+  carries the MagicDNS address.
+
 ### GitHub Actions secrets
 
-Two secrets must be set in **GitHub → Settings → Secrets and variables → Actions**:
+Two secrets must be set in **GitHub → Settings → Secrets and variables → Actions**
+(plus two more if using Tailscale, above):
 
 | Secret | What it is | Where it comes from |
 |--------|-----------|---------------------|

--- a/template/docs/infrastructure.md
+++ b/template/docs/infrastructure.md
@@ -371,26 +371,98 @@ and pragmatic default. The attack surface is small and well-understood.
 
 ### Tailscale (recommended for stricter access control or team use)
 
-If you need tighter network-level security, or you are collaborating with others,
-[Tailscale](https://tailscale.com) is the cleanest upgrade path. It creates a private
-WireGuard mesh between your machines, so you can lock `admin_ips` to Tailscale's CGNAT
-range (`100.64.0.0/10`) and remove the server from the public internet entirely for
-administrative access.
+[Tailscale](https://tailscale.com) puts every node on a private WireGuard mesh, so SSH
+and the Kubernetes API travel over the tailnet instead of the public internet and
+`admin_ips` can be locked to the CGNAT range (`100.64.0.0/10`). Ports 80 and 443 stay
+open — that is public web traffic via Cloudflare.
 
-High-level steps to add Tailscale:
+It ships with the template but is **off by default**. The quickest way to turn it on is
+`/dj-tailscale enable`, which handles both a fresh deploy and an existing cluster. What
+follows is what that skill automates.
 
-1. **Install Tailscale on the K3s node** via cloud-init in `terraform/hetzner/main.tf`,
-   alongside the K3s install script.
-2. **Authenticate the node** with a reusable auth key from the Tailscale admin console
-   (store it in `terraform.tfvars` as a secret, never commit it).
-3. **Lock down `admin_ips`** in `terraform.tfvars` to `["100.64.0.0/10"]` once the node
-   is visible on your Tailnet.
-4. **CI access**: use the official
-   [tailscale/github-action](https://github.com/tailscale/github-action) in your deploy
-   workflow to connect the GitHub Actions runner to your Tailnet before running `helm
-upgrade`. Store the OAuth client credentials as repository secrets.
-5. **Team access**: add team members to your Tailnet and use ACLs to restrict who can
-   reach which ports (e.g. engineers get 6443, ops gets 22).
+#### Setting up
+
+In the Tailscale admin console:
+
+1. Add `tag:k8s` and `tag:ci` to `tagOwners` under Access Controls.
+2. Create an **OAuth client** (Settings → OAuth clients) with the `auth_keys` write
+   scope and both tags.
+3. Note your tailnet name, e.g. `tail1a2b3c.ts.net`.
+
+Then in `terraform/hetzner/terraform.tfvars`:
+
+```hcl
+tailscale_oauth_client_secret = "tskey-client-..."
+tailscale_tailnet             = "tail1a2b3c.ts.net"
+```
+
+**Use an OAuth client, not an auth key.** Auth keys expire after at most 90 days. Because
+adding a node is a routine operation here, an expired key means nodes provisioned later
+silently never reach the tailnet.
+
+#### What happens on apply
+
+Every node installs Tailscale during cloud-init and joins with a pinned hostname
+(`<cluster>-server`, `<cluster>-webapp-1`, …). The server additionally gets its MagicDNS
+name added to the k3s serving certificate as a TLS SAN, and `just get-kubeconfig` writes
+that name as the API address instead of the public IP.
+
+The hostname is pinned rather than left to Tailscale's own normalisation because the TLS
+SAN has to be known at install time — the name cannot be corrected later without
+regenerating the certificate.
+
+#### Adding Tailscale to a cluster that is already running
+
+Cloud-init only runs at node creation, and all servers set
+`lifecycle { ignore_changes = [user_data] }`, so setting the variables is not enough for
+an existing cluster. Two things have to happen on the running nodes:
+
+```bash
+TAILSCALE_OAUTH_CLIENT_SECRET=tskey-client-... \
+TAILSCALE_TAILNET=tail1a2b3c.ts.net \
+  .agents/skills/dj-tailscale/scripts/join-nodes.sh
+```
+
+This installs Tailscale on each node, and on the server writes a
+`/etc/rancher/k3s/config.yaml.d/10-tailscale.yaml` drop-in with the new TLS SAN, clears
+the cached serving certificate and **restarts k3s**. The Kubernetes API is briefly
+unavailable during the restart; running pods are unaffected. The script then checks the
+certificate actually carries the SAN and fails loudly if it does not.
+
+Pass `--dry-run` first to see which nodes it would touch.
+
+#### Locking the firewall — order matters
+
+```hcl
+admin_ips = ["100.64.0.0/10"]
+```
+
+**Never apply this until `kubectl get nodes` has worked over the tailnet.** If any node
+is not on the tailnet when you close port 22, the only way back in is the Hetzner web
+console. Verify first:
+
+```bash
+just get-kubeconfig
+just --yes rkube get nodes
+```
+
+#### CI
+
+The deploy workflow has a Tailscale step that activates only when
+`TS_OAUTH_CLIENT_ID` is set as a repository secret:
+
+```bash
+gh secret set TS_OAUTH_CLIENT_ID
+gh secret set TS_OAUTH_SECRET
+just gh-set-secrets     # re-push the kubeconfig, which now uses the MagicDNS name
+```
+
+Runners join as ephemeral `tag:ci` nodes, so they do not accumulate in your device list.
+
+#### Team access
+
+Add team members to your tailnet and use ACLs to restrict who reaches which ports — for
+example engineers get 6443, ops also gets 22.
 
 ### Secrets
 

--- a/template/just/get-kubeconfig.sh.jinja
+++ b/template/just/get-kubeconfig.sh.jinja
@@ -1,18 +1,36 @@
 #!/usr/bin/env bash
 # Fetch kubeconfig from the K3s server and write it to ~/.kube/{{ project_slug }}.yaml
 # (or the path in $KUBECONFIG if overridden).
+#
+# When Tailscale is enabled the kubeconfig points at the server's MagicDNS name
+# rather than its public IP, so kubectl traffic stays on the tailnet and the
+# Hetzner firewall can keep 6443 closed to the public internet.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TF_DIR="$REPO_ROOT/terraform/hetzner"
 
-SERVER_IP="$(cd "$REPO_ROOT/terraform/hetzner" && terraform output -raw server_public_ip)"
+SERVER_IP="$(cd "$TF_DIR" && terraform output -raw server_public_ip)"
+
+# Null when Tailscale is not enabled, in which case `-raw` fails and we fall
+# back to the public IP.
+TAILSCALE_HOST="$(cd "$TF_DIR" && terraform output -raw server_tailscale_host 2>/dev/null || true)"
+
+API_HOST="${TAILSCALE_HOST:-$SERVER_IP}"
 KUBECONFIG_PATH="${KUBECONFIG:-$HOME/.kube/{{ project_slug }}.yaml}"
+
+if [[ -n "$TAILSCALE_HOST" ]]; then
+    echo "Tailscale enabled - using $TAILSCALE_HOST"
+    if ! command -v tailscale >/dev/null 2>&1; then
+        echo "Warning: tailscale not found locally. You must be on the tailnet to reach this cluster." >&2
+    fi
+fi
 
 mkdir -p "$(dirname "$KUBECONFIG_PATH")"
 
-ssh "ubuntu@$SERVER_IP" 'cat /home/ubuntu/.kube/config' \
-    | sed "s/127.0.0.1/$SERVER_IP/g" \
+ssh "ubuntu@$API_HOST" 'cat /home/ubuntu/.kube/config' \
+    | sed "s/127.0.0.1/$API_HOST/g" \
     > "$KUBECONFIG_PATH"
 
 echo "Kubeconfig written to $KUBECONFIG_PATH"

--- a/template/terraform/hetzner/main.tf.jinja
+++ b/template/terraform/hetzner/main.tf.jinja
@@ -1,5 +1,6 @@
 terraform {
-  required_version = ">= 1.0"
+  # 1.2+ for lifecycle preconditions
+  required_version = ">= 1.2"
 
   required_providers {
     hcloud = {
@@ -35,6 +36,23 @@ locals {
     var.create_database ? "" : "database=true",
   ])
   server_node_label_args = join(" ", [for label in local.server_workload_labels : "--node-label=${label}"])
+
+  # Tailscale (optional). An empty client secret means Tailscale is not enabled.
+  #
+  # Node MagicDNS names are pinned with `tailscale up --hostname` rather than
+  # left to Tailscale's own normalisation, because the k3s serving certificate
+  # must carry the server's MagicDNS name as a SAN at install time. Getting it
+  # wrong cannot be corrected later without regenerating the certificate and
+  # restarting k3s, so the name has to be predictable from Terraform.
+  #
+  # cluster_name may contain underscores, which are not valid in DNS labels.
+  # nonsensitive(): whether Tailscale is on is not itself a secret, and without
+  # this the flag taints every value derived from it - including the MagicDNS
+  # hostname, which get-kubeconfig.sh has to read.
+  tailscale_enabled     = nonsensitive(var.tailscale_oauth_client_secret != "")
+  tailscale_name_prefix = replace(var.cluster_name, "_", "-")
+  server_tailscale_host = local.tailscale_enabled ? "${local.tailscale_name_prefix}-server.${var.tailscale_tailnet}" : ""
+  tailscale_tls_san     = local.tailscale_enabled ? "--tls-san=${local.server_tailscale_host}" : ""
 }
 
 # Private network for internal communication
@@ -211,11 +229,16 @@ resource "hcloud_server" "server" {
   firewall_ids = [hcloud_firewall.server.id]
 
   user_data = templatefile("${path.module}/templates/cloud_init_server.tftpl", {
-    hostname        = "${var.cluster_name}-server"
-    private_ip      = local.server_private_ip
-    k3s_token       = var.k3s_token
-    ssh_public_key  = var.ssh_public_key
-    workload_labels = local.server_node_label_args
+    hostname           = "${var.cluster_name}-server"
+    private_ip         = local.server_private_ip
+    k3s_token          = var.k3s_token
+    ssh_public_key     = var.ssh_public_key
+    workload_labels    = local.server_node_label_args
+    tailscale_enabled  = local.tailscale_enabled
+    tailscale_auth_key = var.tailscale_oauth_client_secret
+    tailscale_tag      = var.tailscale_tag
+    tailscale_hostname = "${local.tailscale_name_prefix}-server"
+    tailscale_tls_san  = local.tailscale_tls_san
   })
 
   labels = {
@@ -237,6 +260,14 @@ resource "hcloud_server" "server" {
 
   lifecycle {
     ignore_changes = [user_data, ssh_keys]
+
+    # Caught at plan time because the consequence is silent: without a tailnet
+    # suffix the TLS SAN would be written as "<name>-server." and every
+    # connection over Tailscale would fail certificate verification.
+    precondition {
+      condition     = var.tailscale_oauth_client_secret == "" || var.tailscale_tailnet != ""
+      error_message = "tailscale_tailnet must be set when tailscale_oauth_client_secret is set (e.g. tail1a2b3c.ts.net)."
+    }
   }
 }
 
@@ -252,10 +283,14 @@ resource "hcloud_server" "database" {
   firewall_ids = [hcloud_firewall.agents.id]
 
   user_data = templatefile("${path.module}/templates/cloud_init_database.tftpl", {
-    hostname          = "${var.cluster_name}-database"
-    server_private_ip = local.server_private_ip
-    k3s_token         = var.k3s_token
-    ssh_public_key    = var.ssh_public_key
+    hostname           = "${var.cluster_name}-database"
+    server_private_ip  = local.server_private_ip
+    k3s_token          = var.k3s_token
+    ssh_public_key     = var.ssh_public_key
+    tailscale_enabled  = local.tailscale_enabled
+    tailscale_auth_key = var.tailscale_oauth_client_secret
+    tailscale_tag      = var.tailscale_tag
+    tailscale_hostname = "${local.tailscale_name_prefix}-database"
   })
 
   labels = {
@@ -300,12 +335,16 @@ resource "hcloud_server" "jobrunner" {
   firewall_ids = [hcloud_firewall.agents.id]
 
   user_data = templatefile("${path.module}/templates/cloud_init_agent.tftpl", {
-    hostname          = "${var.cluster_name}-jobrunner"
-    server_private_ip = local.server_private_ip
-    k3s_token         = var.k3s_token
-    ssh_public_key    = var.ssh_public_key
-    role              = "jobrunner"
-    workload_label    = "--node-label=jobrunner=true"
+    hostname           = "${var.cluster_name}-jobrunner"
+    server_private_ip  = local.server_private_ip
+    k3s_token          = var.k3s_token
+    ssh_public_key     = var.ssh_public_key
+    role               = "jobrunner"
+    workload_label     = "--node-label=jobrunner=true"
+    tailscale_enabled  = local.tailscale_enabled
+    tailscale_auth_key = var.tailscale_oauth_client_secret
+    tailscale_tag      = var.tailscale_tag
+    tailscale_hostname = "${local.tailscale_name_prefix}-jobrunner"
   })
 
   labels = {
@@ -341,12 +380,16 @@ resource "hcloud_server" "webapp" {
   firewall_ids = [hcloud_firewall.agents.id]
 
   user_data = templatefile("${path.module}/templates/cloud_init_agent.tftpl", {
-    hostname          = "${var.cluster_name}-webapp-${count.index + 1}"
-    server_private_ip = local.server_private_ip
-    k3s_token         = var.k3s_token
-    ssh_public_key    = var.ssh_public_key
-    role              = "webapp"
-    workload_label    = "--node-label=webapp=true"
+    hostname           = "${var.cluster_name}-webapp-${count.index + 1}"
+    server_private_ip  = local.server_private_ip
+    k3s_token          = var.k3s_token
+    ssh_public_key     = var.ssh_public_key
+    role               = "webapp"
+    workload_label     = "--node-label=webapp=true"
+    tailscale_enabled  = local.tailscale_enabled
+    tailscale_auth_key = var.tailscale_oauth_client_secret
+    tailscale_tag      = var.tailscale_tag
+    tailscale_hostname = "${local.tailscale_name_prefix}-webapp-${count.index + 1}"
   })
 
   labels = {
@@ -382,12 +425,16 @@ resource "hcloud_server" "monitor" {
   firewall_ids = [hcloud_firewall.monitor[0].id]
 
   user_data = templatefile("${path.module}/templates/cloud_init_agent.tftpl", {
-    hostname          = "${var.cluster_name}-monitor"
-    server_private_ip = local.server_private_ip
-    k3s_token         = var.k3s_token
-    ssh_public_key    = var.ssh_public_key
-    role              = "monitor"
-    workload_label    = ""
+    hostname           = "${var.cluster_name}-monitor"
+    server_private_ip  = local.server_private_ip
+    k3s_token          = var.k3s_token
+    ssh_public_key     = var.ssh_public_key
+    role               = "monitor"
+    workload_label     = ""
+    tailscale_enabled  = local.tailscale_enabled
+    tailscale_auth_key = var.tailscale_oauth_client_secret
+    tailscale_tag      = var.tailscale_tag
+    tailscale_hostname = "${local.tailscale_name_prefix}-monitor"
   })
 
   labels = {

--- a/template/terraform/hetzner/outputs.tf.jinja
+++ b/template/terraform/hetzner/outputs.tf.jinja
@@ -68,6 +68,11 @@ output "tailscale_enabled" {
   value       = local.tailscale_enabled
 }
 
+output "tailscale_name_prefix" {
+  description = "MagicDNS hostname prefix for nodes (cluster_name with underscores replaced by hyphens). The retrofit join script reads this so the hostnames it sets match what cloud-init would have set."
+  value       = local.tailscale_name_prefix
+}
+
 output "server_tailscale_host" {
   description = "MagicDNS name of the server node, or null when Tailscale is not enabled. Used as the kubeconfig API address so kubectl traffic stays on the tailnet."
   value       = local.tailscale_enabled ? local.server_tailscale_host : null

--- a/template/terraform/hetzner/outputs.tf.jinja
+++ b/template/terraform/hetzner/outputs.tf.jinja
@@ -63,6 +63,16 @@ output "postgres_volume_mount_path" {
   value       = "/mnt/HC_Volume_${hcloud_volume.postgres.id}"
 }
 
+output "tailscale_enabled" {
+  description = "Whether nodes join a tailnet at boot"
+  value       = local.tailscale_enabled
+}
+
+output "server_tailscale_host" {
+  description = "MagicDNS name of the server node, or null when Tailscale is not enabled. Used as the kubeconfig API address so kubectl traffic stays on the tailnet."
+  value       = local.tailscale_enabled ? local.server_tailscale_host : null
+}
+
 output "network_id" {
   description = "ID of the private network"
   value       = hcloud_network.private_network.id

--- a/template/terraform/hetzner/templates/cloud_init_agent.tftpl
+++ b/template/terraform/hetzner/templates/cloud_init_agent.tftpl
@@ -37,6 +37,15 @@ write_files:
 
 runcmd:
   - netplan apply
+%{ if tailscale_enabled ~}
+  - |
+    curl -fsSL https://tailscale.com/install.sh | sh
+    tailscale up \
+      --auth-key="${tailscale_auth_key}?preauthorized=true&ephemeral=false" \
+      --advertise-tags=${tailscale_tag} \
+      --hostname=${tailscale_hostname} \
+      --ssh
+%{ endif ~}
   - |
     # Wait for K3s server to be reachable (up to 10 minutes)
     for i in $(seq 1 60); do

--- a/template/terraform/hetzner/templates/cloud_init_database.tftpl
+++ b/template/terraform/hetzner/templates/cloud_init_database.tftpl
@@ -58,6 +58,15 @@ write_files:
 
 runcmd:
   - netplan apply
+%{ if tailscale_enabled ~}
+  - |
+    curl -fsSL https://tailscale.com/install.sh | sh
+    tailscale up \
+      --auth-key="${tailscale_auth_key}?preauthorized=true&ephemeral=false" \
+      --advertise-tags=${tailscale_tag} \
+      --hostname=${tailscale_hostname} \
+      --ssh
+%{ endif ~}
   - |
     # Start volume permission setter in background (volume arrives after cloud-init)
     nohup /usr/local/bin/postgres-volume-perms.sh \

--- a/template/terraform/hetzner/templates/cloud_init_server.tftpl
+++ b/template/terraform/hetzner/templates/cloud_init_server.tftpl
@@ -37,6 +37,17 @@ write_files:
 
 runcmd:
   - netplan apply
+%{ if tailscale_enabled ~}
+  - |
+    # Join the tailnet before installing k3s, so that a failed k3s install can
+    # still be debugged over Tailscale SSH even with admin_ips locked down.
+    curl -fsSL https://tailscale.com/install.sh | sh
+    tailscale up \
+      --auth-key="${tailscale_auth_key}?preauthorized=true&ephemeral=false" \
+      --advertise-tags=${tailscale_tag} \
+      --hostname=${tailscale_hostname} \
+      --ssh
+%{ endif ~}
   - |
     PUBLIC_IP="$(curl -s http://169.254.169.254/hetzner/v1/metadata/public-ipv4)"
     curl -sfL https://get.k3s.io | \
@@ -47,7 +58,7 @@ runcmd:
       --flannel-iface=enp7s0 \
       --advertise-address=${private_ip} \
       --tls-san=${private_ip} \
-      --tls-san="$PUBLIC_IP" \
+      --tls-san="$PUBLIC_IP" ${tailscale_tls_san} \
       --node-label=role=server ${workload_labels}
   - |
     # Copy kubeconfig for ubuntu user

--- a/template/terraform/hetzner/terraform.tfvars.example.jinja
+++ b/template/terraform/hetzner/terraform.tfvars.example.jinja
@@ -36,7 +36,27 @@ postgres_volume_size = 50
 # Run /dj-deploy-observe later to provision it.
 create_monitor = false
 
+# Tailscale (optional) - see docs/infrastructure.md, or run /dj-tailscale.
+#
+# Leave the client secret empty to run without Tailscale. When set, every node
+# joins your tailnet at boot and the kubeconfig points at the server's MagicDNS
+# name instead of its public IP.
+#
+# Use an OAuth *client secret*, not an auth key: auth keys expire after at most
+# 90 days, and an expired key means nodes added later silently fail to join.
+# Create one at login.tailscale.com/admin/settings/oauth with the auth_keys
+# write scope and the tag below.
+#
+# tailscale_oauth_client_secret = "tskey-client-..."
+# tailscale_tailnet             = "tail1a2b3c.ts.net"
+# tailscale_tag                 = "tag:k8s"
+
 # Restrict SSH (22) and K3s API (6443) access to specific IPs.
+#
+# With Tailscale enabled and verified, lock these to the tailnet:
+#   admin_ips = ["100.64.0.0/10"]
+# Ports 80 and 443 stay open regardless - that is public web traffic.
+# Never tighten this before confirming every node is on the tailnet.
 # Set to your own IP or VPN exit IP, e.g. ["203.0.113.42/32"]
 # See docs/k3s-Hetzner-Cloudflare.md for VPN guidance.
 # Default is open (matches Hetzner's default) - restrict before first apply.

--- a/template/terraform/hetzner/variables.tf.jinja
+++ b/template/terraform/hetzner/variables.tf.jinja
@@ -104,3 +104,22 @@ variable "create_monitor" {
   type        = bool
   default     = false
 }
+
+variable "tailscale_oauth_client_secret" {
+  description = "Tailscale OAuth client secret (tskey-client-...). Leave empty to run without Tailscale. OAuth client secrets do not expire, unlike auth keys - which matters because nodes added later must still be able to join. See docs/infrastructure.md."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "tailscale_tailnet" {
+  description = "MagicDNS suffix of your tailnet, e.g. tail1a2b3c.ts.net. Required when tailscale_oauth_client_secret is set: the k3s TLS certificate needs the server's MagicDNS name at install time, so it cannot be discovered afterwards."
+  type        = string
+  default     = ""
+}
+
+variable "tailscale_tag" {
+  description = "ACL tag applied to nodes when they join the tailnet. Must be listed in tagOwners and pre-authorized for the OAuth client."
+  type        = string
+  default     = "tag:k8s"
+}

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -399,6 +399,56 @@ class TestAlwaysIncludedFeatures:
             "? hcloud_server.database[0].id : hcloud_server.server.id"
         ) in content
 
+    def test_tailscale_variables_exist_and_default_to_disabled(self, project):
+        content = (project / "terraform" / "hetzner" / "variables.tf").read_text()
+        for name in (
+            "tailscale_oauth_client_secret",
+            "tailscale_tailnet",
+            "tailscale_tag",
+        ):
+            assert f'variable "{name}"' in content
+        start = content.index('variable "tailscale_oauth_client_secret"')
+        block = content[start : content.index("\n}", start)]
+        assert 'default     = ""' in block, "Tailscale must be off by default"
+        assert "sensitive   = true" in block
+
+    def test_tailscale_enabled_is_not_marked_sensitive(self, project):
+        """Sensitivity propagates from the OAuth secret; without nonsensitive()
+        it taints the MagicDNS host that get-kubeconfig.sh must read."""
+        content = (project / "terraform" / "hetzner" / "main.tf").read_text()
+        assert "nonsensitive(var.tailscale_oauth_client_secret" in content, (
+            "tailscale_enabled must be unwrapped or the outputs fail to validate"
+        )
+
+    def test_tailscale_tailnet_required_when_enabled(self, project):
+        content = (project / "terraform" / "hetzner" / "main.tf").read_text()
+        assert "precondition" in content
+        assert (
+            'var.tailscale_oauth_client_secret == "" || var.tailscale_tailnet != ""'
+            in content
+        )
+
+    def test_cloud_init_tailscale_block_is_conditional(self, project):
+        templates = project / "terraform" / "hetzner" / "templates"
+        for name in (
+            "cloud_init_server.tftpl",
+            "cloud_init_agent.tftpl",
+            "cloud_init_database.tftpl",
+        ):
+            content = (templates / name).read_text()
+            assert "%{ if tailscale_enabled ~}" in content, name
+            assert "tailscale up" in content, name
+            assert "--advertise-tags=${tailscale_tag}" in content, name
+            # hostname is pinned rather than left to Tailscale normalisation,
+            # because the server's TLS SAN is derived from it at install time
+            assert "--hostname=${tailscale_hostname}" in content, name
+
+    def test_server_cert_carries_the_tailnet_san(self, project):
+        content = (
+            project / "terraform" / "hetzner" / "templates" / "cloud_init_server.tftpl"
+        ).read_text()
+        assert '--tls-san="$PUBLIC_IP" ${tailscale_tls_san}' in content
+
     def test_cloud_init_emits_workload_labels(self, project):
         templates = project / "terraform" / "hetzner" / "templates"
         server = (templates / "cloud_init_server.tftpl").read_text()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -483,6 +483,42 @@ class TestAlwaysIncludedFeatures:
         for request in ("memory: 1024Mi", "memory: 768Mi", "memory: 64Mi"):
             assert request in content
 
+    def test_tailscale_skill_is_installed(self, project):
+        skill = project / ".agents" / "skills" / "dj-tailscale"
+        assert (skill / "SKILL.md").exists()
+        assert (skill / "references" / "help.md").exists()
+        script = skill / "scripts" / "join-nodes.sh"
+        assert script.exists()
+        assert script.stat().st_mode & 0o111, "join-nodes.sh must be executable"
+
+    def test_tailscale_skill_files_contain_no_jinja(self, project):
+        """.agents/ is copied verbatim, so unrendered braces would ship as-is."""
+        skill = project / ".agents" / "skills" / "dj-tailscale"
+        for path in skill.rglob("*"):
+            if path.is_file():
+                content = path.read_text()
+                assert "{{" not in content, path
+                assert "{%" not in content, path
+
+    def test_kubeconfig_prefers_the_tailnet_address(self, project):
+        content = (project / "just" / "get-kubeconfig.sh").read_text()
+        assert "server_tailscale_host" in content
+        assert 'API_HOST="${TAILSCALE_HOST:-$SERVER_IP}"' in content
+
+    def test_deploy_workflow_joins_tailnet_conditionally(self, project):
+        content = (project / ".github" / "workflows" / "deploy.yml").read_text()
+        assert "tailscale/github-action@" in content
+        assert "if: ${{ secrets.TS_OAUTH_CLIENT_ID != '' }}" in content
+        # the runner must be on the tailnet before helm tries to reach the API
+        assert content.index("Connect to Tailscale") < content.index(
+            "Deploy to Kubernetes"
+        )
+
+    def test_tailscale_documented_in_all_command_tables(self, project):
+        """AGENTS.md requires the skill tables stay in lockstep."""
+        for rel in ("AGENTS.md", "README.md"):
+            assert "/dj-tailscale" in (project / rel).read_text(), rel
+
     def test_i18n_and_storage_coexist(self, project):
         settings_content = (project / "config" / "settings.py").read_text()
         assert "S3Boto3Storage" in settings_content


### PR DESCRIPTION
Closes #396.

Puts every node on a Tailscale tailnet so SSH and the Kubernetes API travel over WireGuard, letting `admin_ips` close ports 22 and 6443 to the public internet. Ports 80/443 stay open — that's Cloudflare web traffic.

Off by default. `copier.yml` has no feature flags, so this follows the `create_database` / `create_monitor` pattern: shipped always, inert until `tailscale_oauth_client_secret` is set.

## Two paths, because they genuinely differ

| | Day one | Retrofit |
|---|---|---|
| Join nodes | cloud-init, automatic | `join-nodes.sh` over SSH |
| k3s TLS SAN | `--tls-san` at install | drop-in + cert regen + **k3s restart** |
| Everything after | identical | identical |

Existing clusters can't pick this up from Terraform — every server sets `lifecycle { ignore_changes = [user_data] }`. `join-nodes.sh` covers that, and doubles as the recovery path when cloud-init's Tailscale step fails on a fresh node.

## Decisions worth flagging

- **OAuth client secret, not an auth key.** Auth keys expire at 90 days. Since adding a node is routine, an expired key would mean nodes provisioned later silently never join.
- **Hostnames pinned via `--hostname`.** The k3s cert needs the MagicDNS name as a SAN *at install time*, so it must be predictable from Terraform — and `cluster_name` may contain underscores, which aren't valid DNS labels.
- **`nonsensitive()` on the enabled flag.** Sensitivity propagates from the OAuth secret and would otherwise taint the MagicDNS hostname `get-kubeconfig.sh` reads.
- **A `precondition` rejects a secret without a tailnet suffix at plan time** — otherwise the SAN is written as `<name>-server.` and every connection fails verification.

## Lockout safety

`admin_ips` is never tightened until `kubectl get nodes` has succeeded over the tailnet **in the same session**. Getting this wrong leaves the Hetzner web console as the only way in, so `/dj-tailscale disable` reverses the order: firewall first, then Tailscale.

`join-nodes.sh` verifies its own work — it checks the serving certificate actually carries the SAN after the restart and exits non-zero if not, so a failure surfaces immediately rather than as an unexplained TLS error later.

## Verification

- `terraform fmt` + `validate` — pass
- All three cloud-init templates rendered via `terraform console` with the flag both ways: **valid YAML in all six cases**, block present only when enabled
- `shellcheck` + `zizmor` pass on the new script and workflow step
- `pre-commit run --all-files` clean on third pass; `just typecheck` 0 errors
- `pytest tests/` — **142 passed**, 15 new

## Not included

**Headscale.** It needs its own host, DNS, TLS cert and backup story, and every client needs `--login-server` — comparable work to everything here, for a self-hosting purity benefit. Worth its own issue if still wanted.

## Untested against a live cluster

The retrofit cert step (`config.yaml.d` drop-in → remove `dynamic-cert.json` → restart k3s) follows the documented k3s mechanism but I had no running cluster to confirm it against. The script's self-verification is the mitigation: it fails loudly and tells you not to lock the firewall. Worth one real run before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)