### PR TITLE
feat: remove unsafe-inline from CSP script-src using nonces

### DIFF
--- a/template/.agents/skills/dj-create-crud/SKILL.md
+++ b/template/.agents/skills/dj-create-crud/SKILL.md
@@ -172,6 +172,11 @@ def <model_lower>_delete(
 
 ### 3. Templates
 
+The Content-Security-Policy blocks inline scripts without a nonce. If a template
+needs an inline `<script>`, add `nonce="{{ csp_nonce }}"`, and never put user data
+inside Alpine or htmx expression attributes (`x-data`, `@click`, `hx-on:*`). See
+`docs/content-security-policy.md`.
+
 **`templates/<app_name>/<model_lower>_list.html`**
 
 ```html

--- a/template/.agents/skills/dj-create-view/SKILL.md
+++ b/template/.agents/skills/dj-create-view/SKILL.md
@@ -110,6 +110,10 @@ where the template goes, and where the URL is wired.
 
 2. **Create the template** at the path from the table above.
    For HTMX partials, use Django 6 named partial blocks. Use DaisyUI classes for all components.
+   The Content-Security-Policy blocks inline scripts without a nonce: any inline
+   `<script>` must carry `nonce="{{ csp_nonce }}"`, and user data must never go
+   inside Alpine or htmx expression attributes (`x-data`, `@click`, `hx-on:*`).
+   See `docs/content-security-policy.md`.
 
 3. **Wire the URL** in the file from the table above:
    ```python

--- a/template/.agents/skills/dj-secure/SKILL.md
+++ b/template/.agents/skills/dj-secure/SKILL.md
@@ -69,7 +69,14 @@ If `terraform/cloudflare/` does not exist, apply the standard WARNING check.
 
 **Note on CSP `'unsafe-eval'`:** `'unsafe-eval'` in `script-src` is expected — the
 standard Alpine build and htmx `hx-on:*` / trigger filters / `js:` values need it.
-Do not flag it. Do flag as **WARNING** any inline `<script>` in `templates/`
+Report it as **ADVISORY** only, and do not recommend removing it on its own:
+it requires the Alpine CSP build plus either dropping htmx eval features or the
+`hx-csp` extension (with `hx-nonce` on every htmx element). Read
+`docs/content-security-policy.md` and summarise that cost if the user asks.
+Separately, flag as **CRITICAL** any user-controlled data rendered inside Alpine
+or htmx expression attributes (`x-data`, `x-init`, `@...`, `hx-on:*`, `js:`
+values) — with `'unsafe-eval'` allowed, these execute.
+Also flag as **WARNING** any inline `<script>` in `templates/`
 without `nonce="{{ csp_nonce }}"` — it is blocked by the policy and will not run.
 
 **Note on `SECRET_KEY` with a `django-insecure-*` default:** A pattern like

--- a/template/.agents/skills/dj-secure/SKILL.md
+++ b/template/.agents/skills/dj-secure/SKILL.md
@@ -49,6 +49,7 @@ For each setting, apply this decision tree:
 | `X_FRAME_OPTIONS` | `"DENY"` or `"SAMEORIGIN"` | WARNING |
 | `SECURE_HSTS_INCLUDE_SUBDOMAINS` | `True` | ADVISORY |
 | CSP headers | middleware or header present | WARNING |
+| `SECURE_CSP` `script-src` | no `'unsafe-inline'` (inline scripts use `CSP.NONCE`) | WARNING |
 | Django admin URL | not `"admin/"` | ADVISORY |
 | `DEBUG_TOOLBAR` in `INSTALLED_APPS` | guarded by `DEBUG` check | WARNING |
 
@@ -65,6 +66,11 @@ ADVISORY: [settings] SECURE_HSTS_SECONDS not set — not applicable, HSTS is han
 ```
 
 If `terraform/cloudflare/` does not exist, apply the standard WARNING check.
+
+**Note on CSP `'unsafe-eval'`:** `'unsafe-eval'` in `script-src` is expected — the
+standard Alpine build and htmx `hx-on:*` / trigger filters / `js:` values need it.
+Do not flag it. Do flag as **WARNING** any inline `<script>` in `templates/`
+without `nonce="{{ csp_nonce }}"` — it is blocked by the policy and will not run.
 
 **Note on `SECRET_KEY` with a `django-insecure-*` default:** A pattern like
 `SECRET_KEY = env("SECRET_KEY", default="django-insecure-...")` is **not CRITICAL**.

--- a/template/AGENTS.md.jinja
+++ b/template/AGENTS.md.jinja
@@ -173,6 +173,7 @@ actively, not as background reading.
 | Multi-tenancy (django-tenants)  | `docs/tenants.md` |
 | HTMX interaction                | `docs/htmx.md` |
 | AlpineJS component              | `docs/alpine.md` |
+| Content Security Policy, inline scripts, `'unsafe-eval'` | `docs/content-security-policy.md` |
 | Dropdown menus                            | `docs/ui-recipes.md` |
 | Lightbox, drag-drop, upload preview       | `docs/ui-recipes.md` |
 | Maps / geocoding (OpenStreetMap + geopy)  | `docs/maps.md` |

--- a/template/config/settings.py.jinja
+++ b/template/config/settings.py.jinja
@@ -143,6 +143,7 @@ TEMPLATES = [
             ],
             "debug": env.bool("TEMPLATE_DEBUG", default=DEBUG),
             "context_processors": [
+                "django.template.context_processors.csp",
                 "django.template.context_processors.debug",
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
@@ -391,11 +392,12 @@ PERMISSIONS_POLICY: dict[str, list] = {
 
 CSP_SCRIPT_WHITELIST = env.list("CSP_SCRIPT_WHITELIST", default=[])
 
-# NOTE: HTMX and Alpine require 'unsafe-inline' and 'unsafe-eval'
+# Inline <script> tags must set their nonce attribute from the csp_nonce template variable.
+# NOTE: 'unsafe-eval' is required by Alpine expressions and htmx hx-on/filters/js:
 SCRIPT_SCP = [
     CSP.SELF,
+    CSP.NONCE,
     CSP.UNSAFE_EVAL,
-    CSP.UNSAFE_INLINE,
     *CSP_SCRIPT_WHITELIST,
 ]
 

--- a/template/docs/alpine.md
+++ b/template/docs/alpine.md
@@ -16,6 +16,7 @@ Alpine.js provides reactive JavaScript behavior without writing JavaScript files
 - [Array and Counter Mutations](#array-and-counter-mutations)
 - [Best Practices](#best-practices)
 - [Script Loading Order](#script-loading-order)
+- [Content Security Policy](#content-security-policy)
 
 ## Installation
 
@@ -318,12 +319,13 @@ Follow this progression based on component complexity:
 ```
 
 **2. Complex logic** — move to `Alpine.data()` in a `<script>` tag inside the
-page's `{% block scripts %}` block (rendered in the footer, before `</body>`):
+page's `{% block scripts %}` block (rendered in the footer, before `</body>`).
+Inline scripts need the CSP nonce (see [Content Security Policy](#content-security-policy)):
 
 ```html
 {% block scripts %}
   {{ block.super }}
-  <script>
+  <script nonce="{{ csp_nonce }}">
     document.addEventListener('alpine:init', () => {
       Alpine.data('myComponent', (param) => ({
         value: param,
@@ -426,3 +428,24 @@ onDrop() {
 
 This keeps all URL knowledge in the template layer where Django's `{% url %}` tag
 can reverse them correctly, and avoids breakage when URL patterns change.
+
+## Content Security Policy
+
+`script-src` does not allow `'unsafe-inline'`, so the browser blocks any inline
+`<script>` without the per-request nonce. Add `nonce="{{ csp_nonce }}"` to every
+inline script (the `csp` context processor provides `csp_nonce`):
+
+```html
+<script nonce="{{ csp_nonce }}">
+  document.addEventListener('alpine:init', () => { ... });
+</script>
+```
+
+- Scripts loaded with `<script src="{% static '...' %}">` need no nonce.
+- `{{ data|json_script:"id" }}` output is not executed, so it needs no nonce.
+- Inline event handler attributes (`onclick="..."`) are blocked — use Alpine
+  directives (`@click`) instead.
+
+`'unsafe-eval'` stays in `script-src`: the standard Alpine build evaluates
+directive expressions at runtime, as do htmx's `hx-on:*`, trigger filters and
+`js:` values.

--- a/template/docs/alpine.md
+++ b/template/docs/alpine.md
@@ -448,4 +448,5 @@ inline script (the `csp` context processor provides `csp_nonce`):
 
 `'unsafe-eval'` stays in `script-src`: the standard Alpine build evaluates
 directive expressions at runtime, as do htmx's `hx-on:*`, trigger filters and
-`js:` values.
+`js:` values. For what that costs and how to remove it (Alpine CSP build,
+htmx `hx-csp`), see `docs/content-security-policy.md`.

--- a/template/docs/content-security-policy.md
+++ b/template/docs/content-security-policy.md
@@ -1,0 +1,245 @@
+# Content Security Policy
+
+The project sends a `Content-Security-Policy` header on every response using
+Django's built-in CSP support (`SECURE_CSP` in `config/settings.py`). This doc
+explains what the script policy allows, what it costs, and how to tighten it
+further if a project needs to.
+
+## Contents
+
+- [Current policy](#current-policy)
+- [Inline scripts and nonces](#inline-scripts-and-nonces)
+- [Why 'unsafe-eval' is allowed](#why-unsafe-eval-is-allowed)
+- [Removing 'unsafe-eval'](#removing-unsafe-eval)
+  - [Alpine: the CSP build](#alpine-the-csp-build)
+  - [htmx: the hx-csp extension](#htmx-the-hx-csp-extension)
+  - [Pitfalls](#pitfalls)
+  - [Checklist](#checklist)
+- [References](#references)
+
+## Current policy
+
+```python
+SCRIPT_SCP = [
+    CSP.SELF,
+    CSP.NONCE,
+    CSP.UNSAFE_EVAL,
+    *CSP_SCRIPT_WHITELIST,
+]
+```
+
+| Source | Allowed | Why |
+| --- | --- | --- |
+| `'self'` | yes | Vendored and project scripts under `static/` |
+| Nonce | yes | Inline `<script>` tags rendered with the per-request nonce |
+| `'unsafe-inline'` | **no** | Injected `<script>` tags and `onclick="..."` handlers are blocked |
+| `'unsafe-eval'` | yes | Alpine directive expressions and htmx `hx-on:*`, trigger filters and `js:` values |
+
+`style-src` still allows `'unsafe-inline'`; this doc covers `script-src` only.
+
+## Inline scripts and nonces
+
+Every inline `<script>` must carry the nonce, provided by the
+`django.template.context_processors.csp` context processor:
+
+```html
+<script nonce="{{ csp_nonce }}">
+  document.addEventListener('alpine:init', () => { ... });
+</script>
+```
+
+- `<script src="{% static '...' %}">` needs no nonce.
+- `{{ data|json_script:"id" }}` is not executed and needs no nonce.
+- Inline event handler attributes (`onclick="..."`) cannot be nonced — use
+  Alpine directives (`@click`) instead.
+- Django only generates a nonce when a template reads `csp_nonce`, so pages
+  without inline scripts pay nothing.
+
+A missing nonce fails in the browser console ("Executing inline script violates
+the following Content Security Policy directive…"), not on the server. The E2E
+test `test_no_content_security_policy_violations` catches this on the base
+template.
+
+## Why 'unsafe-eval' is allowed
+
+`'unsafe-eval'` lets JavaScript compile strings into code (`Function`,
+`eval`). Two core parts of the stack rely on it:
+
+- **Alpine (standard build)** compiles every directive expression
+  (`x-data`, `@click`, `x-show`, `x-init`, ...) with `Function`.
+- **htmx** compiles `hx-on:*` handlers, trigger filters
+  (`hx-trigger="click[shiftKey]"`) and `js:` / `javascript:` values
+  (e.g. in `hx-vals`, `hx-confirm`) with `Function`/`AsyncFunction`.
+
+**The cost:** nonces stop an attacker who can inject HTML from running an
+injected `<script>`, but not from injecting markup that Alpine or htmx will
+evaluate — for example `<div x-init="...">` or `<div hx-on:load="...">`. The
+first line of defence remains Django's auto-escaping: never render user content
+with `|safe` / `mark_safe`, never put user data inside Alpine or htmx expression
+attributes, and never use `x-html` with user content.
+
+Removing `'unsafe-eval'` closes that gap, but it is a significant change to how
+templates are written. The template keeps it by default; the sections below
+describe what removing it involves.
+
+## Removing 'unsafe-eval'
+
+Both Alpine and htmx must be dealt with — removing it for only one of them
+gains nothing, since the other still evaluates injected attributes.
+
+### Alpine: the CSP build
+
+Alpine publishes a CSP-compatible build (`@alpinejs/csp`) that parses directive
+expressions itself instead of using `Function`.
+
+1. Switch the `alpinejs` entry in `vendors.json` (keep the same `dest`), then run
+   `just dj sync_vendors --no-input`:
+
+   ```json
+   "alpinejs": {
+     "version": "3.17.2",
+     "repo": "alpinejs/alpine",
+     "source": "https://cdn.jsdelivr.net/npm/@alpinejs/csp@{version}/dist/cdn.min.js",
+     "dest": "static/vendor/alpine.js"
+   }
+   ```
+
+2. Rewrite expressions the CSP build cannot parse. It **supports** property
+   access, method calls, assignments, comparison/logical/arithmetic operators,
+   ternaries, inline `x-data` objects, `x-model`, `x-for`, `$el`, `$event`.
+   It **rejects**:
+
+   - arrow functions: `setTimeout(() => show = false, 4000)`
+   - template literals, destructuring and spread: `` `${a}` ``, `[...items]`
+   - globals: `document`, `window`, `JSON`, `Math`, `console`, `setTimeout`
+   - `x-html`
+
+   In the shipped template this affects `templates/messages.html`
+   (`setTimeout` in `x-init`) and `templates/navbar.html` (`$watch` with arrow
+   functions). Several examples in `docs/alpine.md` and `docs/ui-recipes.md`
+   (e.g. `JSON.parse(document.getElementById(...))`) also need rewriting.
+
+3. Move that logic into registered components, in a static file or a nonced
+   inline script. Plain JavaScript inside `Alpine.data()` is unrestricted — only
+   directive attribute expressions are parsed:
+
+   ```js
+   // static/components.js
+   document.addEventListener('alpine:init', () => {
+     Alpine.data('message', () => ({
+       show: true,
+       init() {
+         setTimeout(() => { this.show = false; }, 4000);
+       },
+     }));
+   });
+   ```
+
+   ```html
+   <div x-data="message" x-show="show" role="alert">...</div>
+   ```
+
+   Pass server data as component arguments (`x-data="lightbox('photos-data')"`)
+   and read `json_script` output inside the component, not in the attribute.
+
+### htmx: the hx-csp extension
+
+There are two choices:
+
+- **Stop using the eval features:** no `hx-on:*`, no trigger filters, no `js:`
+  values. Handle htmx events with Alpine listeners
+  (`@htmx:after:swap="..."`) or code in a registered component. Nothing else
+  changes. Practical only if a project genuinely does not need them.
+- **Use htmx's `hx-csp` extension** with `safeEval`, which runs those
+  expressions through nonced `<script>` injection instead of `Function`. It
+  ships in the `htmx.org` package.
+
+To adopt `hx-csp`:
+
+1. Vendor it alongside htmx (same `repo` and version as the `htmx` entry):
+
+   ```json
+   "htmx-ext-csp": {
+     "version": "4.0.0",
+     "repo": "bigskysoftware/htmx",
+     "source": "https://cdn.jsdelivr.net/npm/htmx.org@{version}/dist/ext/hx-csp.js",
+     "dest": "static/vendor/hx-csp.js"
+   }
+   ```
+
+2. Enable it. Upstream shows the config as a meta tag — set the equivalent keys
+   in `HTMX_CONFIG` and check the rendered `<meta name="htmx-config">`:
+
+   ```html
+   <meta name="htmx-config" content='extensions:"hx-csp",safeEval:true'>
+   ```
+
+3. Load `hx-csp.js` after `htmx.js`, and give **both script tags a nonce**. The
+   extension reads the page nonce from the first `script[nonce]` element when it
+   initialises; the only nonced script in `base.html` is at the bottom of
+   `<body>`, so without this the extension finds no nonce and blocks all htmx.
+
+   ```html
+   <script src="{% static 'vendor/htmx.js' %}" nonce="{{ csp_nonce }}"></script>
+   <script src="{% static 'vendor/hx-csp.js' %}" nonce="{{ csp_nonce }}"></script>
+   ```
+
+4. Stamp `hx-nonce` on **every element with `hx-*` attributes**, in full pages
+   and in partial responses:
+
+   ```html
+   <button hx-post="{% url 'save' %}" hx-nonce="{{ csp_nonce }}">Save</button>
+   ```
+
+   The extension compares each element's `hx-nonce` with the page nonce. For
+   swapped responses it reads the nonce from the response's CSP header and
+   rewrites it to the page nonce (same-origin only), so partials render
+   `{{ csp_nonce }}` like any other template.
+
+5. Add `HX-Request-Type` to the `Vary` header (alongside `HX-Request` in
+   `HtmxCacheMiddleware`) so full pages and partials are cached separately.
+
+6. Optionally enforce Trusted Types: the extension creates an `htmx` policy, so
+   add `require-trusted-types-for 'script'` and `trusted-types htmx` to
+   `SECURE_CSP`.
+
+### Pitfalls
+
+- **Missing `hx-nonce` breaks elements quietly.** The extension strips the
+  element's `hx-*` attributes and logs
+  `htmx: [hx-csp] blocked <tag#id>: no hx-nonce attribute` to the console (and
+  fires `htmx:security:strip`). The page still renders; the element just does
+  nothing. Every new template, partial, doc example and generator skill has to
+  include it.
+- **Do not use `hx-nonce:inherited` on `<body>` as a shortcut.** htmx resolves
+  `hx-nonce` through normal attribute inheritance, so it does silence the
+  errors — but injected markup inside `<body>` inherits the nonce too, which
+  removes the protection the extension exists to provide. Stamp each element.
+- **Cached markup carries stale nonces.** A nonce is per request; HTML cached
+  with `@cache_page` or `{% cache %}` embeds an old one. The extension treats a
+  nonce it did not expect as stolen and strips it, leaving the cached elements
+  inert. Do not cache rendered htmx markup, or cache data rather than HTML.
+- **User data in eval attributes is still unsafe.** `safeEval` changes how
+  expressions run, not what they can do. HTML escaping does not neutralise
+  JavaScript inside `hx-on:*` or `js:` values.
+
+### Checklist
+
+1. Alpine: switch to the CSP build, rewrite unsupported expressions, move logic
+   into `Alpine.data()` components.
+2. htmx: remove eval features, or adopt `hx-csp` (vendor, config, nonced script
+   tags, `hx-nonce` everywhere, `Vary: HX-Request-Type`).
+3. Remove `CSP.UNSAFE_EVAL` from `SCRIPT_SCP` in `config/settings.py`.
+4. Update `docs/alpine.md`, `docs/htmx.md`, `docs/ui-recipes.md` and any skill
+   that generates Alpine or htmx markup to follow the new rules.
+5. Tests: assert `'unsafe-eval'` is absent from `script-src` in the CSP unit
+   test, and keep `test_no_content_security_policy_violations` passing. Extend
+   E2E coverage to pages that use htmx and Alpine interactions — CSP failures
+   only show up in the browser.
+
+## References
+
+- [Django CSP reference](https://docs.djangoproject.com/en/6.1/ref/csp/)
+- [Alpine CSP build](https://alpinejs.dev/advanced/csp)
+- [htmx hx-csp extension](https://four.htmx.org/extensions/hx-csp/)
+- [htmx security docs](https://four.htmx.org/docs/)

--- a/template/docs/django-templates.md
+++ b/template/docs/django-templates.md
@@ -28,12 +28,12 @@ This project uses Django templates with HTMX, including the `partialdef` pattern
 {% endblock content %}
 ```
 
-The `{% block scripts %}` block is rendered just before `</body>` — use it for per-page JavaScript:
+The `{% block scripts %}` block is rendered just before `</body>` — use it for per-page JavaScript. Inline scripts must carry the CSP nonce (see `docs/alpine.md`):
 
 ```html
 {% block scripts %}
   {{ block.super }}
-  <script>
+  <script nonce="{{ csp_nonce }}">
     document.addEventListener('alpine:init', () => {
       Alpine.data('myComponent', () => ({ ... }));
     });

--- a/template/docs/django.md
+++ b/template/docs/django.md
@@ -115,7 +115,7 @@ SECURE_CSP = {
 `nonce="{{ csp_nonce }}"` (provided by the `django.template.context_processors.csp`
 context processor). `'unsafe-eval'` is kept because Alpine expressions and htmx
 `hx-on:*` / trigger filters / `js:` values are evaluated at runtime. See
-`docs/alpine.md#content-security-policy`.
+`docs/content-security-policy.md` for the trade-off and how to remove it.
 
 ```python
 

--- a/template/docs/django.md
+++ b/template/docs/django.md
@@ -94,8 +94,8 @@ CSP_SCRIPT_WHITELIST = env.list("CSP_SCRIPT_WHITELIST", default=[])
 
 SCRIPT_SRC = [
     CSP.SELF,
+    CSP.NONCE,
     CSP.UNSAFE_EVAL,
-    CSP.UNSAFE_INLINE,
     *CSP_SCRIPT_WHITELIST,
 ]
 
@@ -109,6 +109,15 @@ SECURE_CSP = {
     "img-src": [CSP.SELF, CSP_DATA],  # add "blob:" for instant-preview file upload widgets
     "media-src": ["*"],
 }
+```
+
+`script-src` has no `'unsafe-inline'`: inline `<script>` tags must carry
+`nonce="{{ csp_nonce }}"` (provided by the `django.template.context_processors.csp`
+context processor). `'unsafe-eval'` is kept because Alpine expressions and htmx
+`hx-on:*` / trigger filters / `js:` values are evaluated at runtime. See
+`docs/alpine.md#content-security-policy`.
+
+```python
 
 SECURE_SSL_REDIRECT = env.bool("SECURE_SSL_REDIRECT", default=USE_HTTPS)
 SECURE_HSTS_INCLUDE_SUBDOMAINS = env.bool("SECURE_HSTS_INCLUDE_SUBDOMAINS", default=False)

--- a/template/docs/htmx.md
+++ b/template/docs/htmx.md
@@ -15,6 +15,7 @@ HTMX is vendored into `static/vendor/`. To update it or add new JS dependencies,
 - [Loading Indicator CSS](#loading-indicator-css)
 - [Extensions](#extensions)
 - [Best Practices](#best-practices)
+- [Content Security Policy](#content-security-policy)
 - [References](#references)
 
 ## Configuration
@@ -338,6 +339,15 @@ See [four.htmx.org/extensions](https://four.htmx.org/extensions/) for the full l
 4. Debounce search inputs: `hx-trigger="keyup changed delay:300ms"`.
 5. Use `hx-swap="outerHTML"` to replace a form with its re-rendered self on validation errors.
 6. Use `hx-swap="delete"` to dismiss banners or remove list items after a destructive action.
+
+## Content Security Policy
+
+`hx-on:*` handlers, trigger filters (`hx-trigger="click[shiftKey]"`) and `js:` /
+`javascript:` values are compiled at runtime with `Function`, so they depend on
+`'unsafe-eval'` in `script-src`. The project's policy allows it. Removing it
+requires either dropping these features or adopting the `hx-csp` extension,
+which needs `hx-nonce` on every htmx element — see
+`docs/content-security-policy.md` before changing the policy.
 
 ## References
 

--- a/template/docs/ui-recipes.md
+++ b/template/docs/ui-recipes.md
@@ -21,7 +21,7 @@ Register it once in your base template's `{% block scripts %}` block:
 
 ```html
 {% block scripts %} {{ block.super }}
-<script>
+<script nonce="{{ csp_nonce }}">
   document.addEventListener("alpine:init", () => {
     Alpine.data("dropdown", () => ({
       open: false,
@@ -209,7 +209,7 @@ Place in `{% block scripts %}` (no `defer`):
 
 ```html
 {% block scripts %} {{ block.super }}
-<script>
+<script nonce="{{ csp_nonce }}">
   document.addEventListener("alpine:init", () => {
     Alpine.data("lightbox", (photos) => ({
       open: false,
@@ -370,7 +370,7 @@ action URL are passed as constructor arguments so the component stays reusable.
 
 ```html
 {% block scripts %} {{ block.super }}
-<script>
+<script nonce="{{ csp_nonce }}">
   document.addEventListener("alpine:init", () => {
     Alpine.data("dragDrop", (csrfHeader, csrfToken, actionUrl) => ({
       dragging: null,
@@ -463,7 +463,7 @@ across pages:
 
 ```html
 {% block scripts %} {{ block.super }}
-<script>
+<script nonce="{{ csp_nonce }}">
   document.addEventListener("alpine:init", () => {
     Alpine.data("fileUpload", () => ({
       files: [],

--- a/template/templates/base.html
+++ b/template/templates/base.html
@@ -22,7 +22,7 @@
     {% cookie_banner %}
     {% block scripts %}
     <script src="{% static 'indicator.js' %}"></script>
-    <script>
+    <script nonce="{{ csp_nonce }}">
       document.addEventListener('htmx:before:request', (evt) => {
         evt.detail.ctx?.target?.setAttribute('aria-busy', 'true');
       });

--- a/template/{{ package_name }}/tests/test_playwright.py
+++ b/template/{{ package_name }}/tests/test_playwright.py
@@ -1,0 +1,21 @@
+"""E2E tests for site-wide page behaviour."""
+
+from typing import TYPE_CHECKING
+
+import pytest
+from django.urls import reverse
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Page
+
+pytestmark = [pytest.mark.e2e, pytest.mark.django_db(transaction=True)]
+
+
+def test_no_content_security_policy_violations(page: Page, live_server):
+    """Scripts on the base template run under the Content-Security-Policy."""
+    console: list[str] = []
+    # Playwright inspects the handler signature, so leave it unannotated
+    page.on("console", lambda message: console.append(message.text))
+    page.goto(f"{live_server.url}{reverse('index')}")
+    page.wait_for_load_state("networkidle")
+    assert [text for text in console if "Content Security Policy" in text] == []

--- a/template/{{ package_name }}/tests/test_views.py.jinja
+++ b/template/{{ package_name }}/tests/test_views.py.jinja
@@ -11,6 +11,30 @@ class TestIndex:
 
 
 @pytest.mark.django_db
+class TestContentSecurityPolicy:
+    def _script_src(self, response):
+        directives = (
+            directive.strip().split()
+            for directive in response.headers["Content-Security-Policy"].split(";")
+        )
+        return next(values for name, *values in directives if name == "script-src")
+
+    def test_script_src_has_no_unsafe_inline(self, client):
+        response = client.get(reverse("index"))
+        assert "'unsafe-inline'" not in self._script_src(response)
+
+    def test_inline_script_nonce_matches_header(self, client):
+        response = client.get(reverse("index"))
+        nonces = [
+            value.removeprefix("'nonce-").removesuffix("'")
+            for value in self._script_src(response)
+            if value.startswith("'nonce-")
+        ]
+        assert len(nonces) == 1
+        assert f'nonce="{nonces[0]}"'.encode() in response.content
+
+
+@pytest.mark.django_db
 class TestAbout:
     def test_get(self, client):
         response = client.get(reverse("about"))

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -75,6 +75,14 @@ class TestProjectContent:
         content = (project / "config" / "settings.py").read_text()
         assert '"test_project",' in content
 
+    def test_csp_script_src_uses_nonce_not_unsafe_inline(self, project):
+        content = (project / "config" / "settings.py").read_text()
+        script_src = content[content.index("SCRIPT_SCP = [") :]
+        script_src = script_src[: script_src.index("]")]
+        assert "CSP.NONCE" in script_src
+        assert "CSP.UNSAFE_INLINE" not in script_src
+        assert '"django.template.context_processors.csp",' in content
+
     def test_gha_build_workflow_has_project_slug(self, project):
         content = (project / ".github" / "workflows" / "build.yml").read_text()
         assert "test_project" in content


### PR DESCRIPTION
Tightens the Content-Security-Policy for #406 by removing `'unsafe-inline'` from `script-src`. `'unsafe-eval'` stays, deliberately.

Refs #406. This doesn't close it.

## Why `'unsafe-eval'` stays

Removing `'unsafe-eval'` would need both the Alpine CSP build and a fix for htmx:

- htmx core evaluates `hx-on:*`, trigger filters (`click[shiftKey]`) and `js:` values at runtime with `Function`, so dropping `'unsafe-eval'` disables them.
- htmx's `hx-csp` extension restores them, but requires `hx-nonce` on every htmx element, including those in partial responses. A missing nonce makes the element inert.
- Setting `hx-nonce:inherited` once on `<body>` avoids the per-element stamping, but injected markup inherits the nonce too. That removes the protection the nonce gating provides.

Neither route is worth losing `hx-on` or adding per-element nonces in this template. This PR takes the high-value, low-cost part: blocking injected inline `<script>` tags.

## Changes

- **Settings:** `script-src` is now `'self'`, the nonce, `'unsafe-eval'`, and the whitelist. The `django.template.context_processors.csp` context processor is added.
- **`base.html`:** its inline script carries `nonce="{{ csp_nonce }}"`.
- **Docs:** inline `<script>` examples use the nonce (`alpine.md`, `django-templates.md`, `ui-recipes.md`). `django.md` shows the new policy. A new "Content Security Policy" section in `alpine.md` explains nonces and why `'unsafe-eval'` remains.
- **`/dj-secure`:** flags `'unsafe-inline'` in `script-src` and inline scripts without a nonce. It doesn't flag the expected `'unsafe-eval'`.

## Docs: the `'unsafe-eval'` trade-off

`docs/content-security-policy.md` records why `'unsafe-eval'` stays, what that costs, and how a project could remove it:

- **Alpine:** switch to the CSP build and move logic into components.
- **htmx:** drop the eval features, or adopt `hx-csp`. That means nonced script tags, `hx-nonce` on every htmx element, and `Vary: HX-Request-Type`.
- **Pitfalls:** `hx-nonce:inherited` removes the protection, and cached markup carries stale nonces.

It's linked from `alpine.md`, `htmx.md`, `django.md` and `AGENTS.md`, and from the `/dj-secure`, `/dj-create-view` and `/dj-create-crud` skills. `/dj-secure` now reports `'unsafe-eval'` as ADVISORY and flags user data inside Alpine or htmx expression attributes as CRITICAL.

## Tests

- **Unit:** `script-src` has no `'unsafe-inline'`, and the nonce in the header matches the one rendered in the page.
- **E2E:** `test_no_content_security_policy_violations` fails if the browser logs a CSP violation. I checked it: removing the nonce from `base.html` makes it fail with Chrome's "Executing inline script violates the following Content Security Policy directive…"
- **Repo:** rendered `settings.py` uses `CSP.NONCE`, not `CSP.UNSAFE_INLINE`, in `script-src`, and includes the `csp` context processor.

Checked on a freshly generated project:

- Pre-commit is clean by the third pass.
- `just check-all` passes (139 unit and 5 E2E tests).
- Repo-level `pytest tests/` passes (143 tests).

I also checked third-party templates for inline scripts that this change would break. Admin, debug-toolbar and browser-reload have none. The only one is allauth's headless Swagger page, which the template doesn't use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

