### PR TITLE
feat: remove hardcoded secret key in settings

### DIFF
--- a/template/.env.example.jinja
+++ b/template/.env.example.jinja
@@ -1,7 +1,7 @@
 # Enable Django debug mode
 DEBUG=true
 # Django secret key
-SECRET_KEY=django-insecure-change-me-in-development
+SECRET_KEY=django-insecure-development-only
 # PostgreSQL database URL
 DATABASE_URL=postgresql://postgres:password@127.0.0.1:5432/postgres
 # Redis URL

--- a/template/.github/workflows/checks.yml
+++ b/template/.github/workflows/checks.yml
@@ -69,4 +69,7 @@ jobs:
       - run: uv sync --frozen --all-extras --no-install-project
       - run: uv run playwright install --with-deps chromium
       - run: uv run python manage.py tailwind build
+        env:
+          # settings.py requires SECRET_KEY. Placeholder for CI only, not a secret.
+          SECRET_KEY: django-insecure-ci-only
       - run: uv run pytest -c playwright.ini

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -30,13 +30,18 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends gettext=0.21-12 \
   && rm -rf /var/lib/apt/lists/*
 
+# settings.py requires SECRET_KEY. This placeholder is not a secret: it is only
+# used by build-time management commands and never reaches the final image.
+# The real key is supplied at runtime via the environment (Helm secret).
 RUN --mount=type=cache,target=/root/.cache/uv \
-  uv run python manage.py compilemessages
+  SECRET_KEY=django-insecure-build-only uv run python manage.py compilemessages
 
 # Build static assets
 FROM python-base AS staticfiles
 COPY . .
+# Build-only SECRET_KEY placeholder (not a secret) - see messages stage above.
 RUN --mount=type=cache,target=/root/.cache/uv \
+  export SECRET_KEY=django-insecure-build-only && \
   uv run python manage.py tailwind build && \
   uv run python manage.py tailwind remove_cli && \
   uv run python manage.py collectstatic --no-input

--- a/template/config/settings.py.jinja
+++ b/template/config/settings.py.jinja
@@ -27,10 +27,7 @@ env.read_env()
 
 DEBUG = env.bool("DEBUG", default=False)
 
-SECRET_KEY = env(
-    "SECRET_KEY",
-    default="django-insecure-change-me-in-production",
-)
+SECRET_KEY = env("SECRET_KEY")
 
 SECRET_KEY_FALLBACKS = env.list("SECRET_KEY_FALLBACKS", default=[])
 

--- a/template/docs/django.md
+++ b/template/docs/django.md
@@ -43,7 +43,7 @@ env = Env()
 env.read_env()
 
 DEBUG = env.bool("DEBUG", default=False)
-SECRET_KEY = env("SECRET_KEY", default="...")
+SECRET_KEY = env("SECRET_KEY")
 ```
 
 ### Database with Connection Pooling

--- a/template/playwright.ini.jinja
+++ b/template/playwright.ini.jinja
@@ -3,8 +3,11 @@ DJANGO_SETTINGS_MODULE = config.settings
 asyncio_mode = auto
 addopts = -v -x --tb=short -p no:warnings --browser chromium -m e2e
 testpaths = {{ package_name }}
+# settings.py requires SECRET_KEY. The SECRET_KEY below is a placeholder so E2E
+# tests run without a .env (e.g. in CI). Not a secret: test-only value.
 env =
     DJANGO_ALLOW_ASYNC_UNSAFE=true
+    SECRET_KEY=django-insecure-test-only
     USE_CONNECTION_POOL=false
     USE_COLLECTSTATIC=false
     USE_HTTPS=false

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -96,6 +96,9 @@ testpaths = ["{{ package_name }}", "templates"]
 env = [
   "COVERAGE_CORE=sysmon",
   "DJANGO_ALLOW_ASYNC_UNSAFE=true",
+  # settings.py requires SECRET_KEY. Placeholder so tests run without a .env
+  # (e.g. in CI). Not a secret: test-only value.
+  "SECRET_KEY=django-insecure-test-only",
   "USE_CONNECTION_POOL=false",
   "USE_COLLECTSTATIC=false",
   "USE_HTTPS=false",


### PR DESCRIPTION
Removes the hard-coded `SECRET_KEY` in settings. While this is normally caught by `./manage.py check` it still opens a potential security hole if that check is ever bypassed. Therefore `SECRET_KEY` must be provided by the runtime environment.

We provide a hard-coded secret key environment variable in the following cases, where's it's safe and justified:

1. The `.env.example` file used for bootstrapping the development environment
2. Production Dockerfile for running builds using Django management commands e.g. `collectstatic` or `compilemessages`
3. Unit and E2E tests 
4. CI checks

In production, the `SECRET_KEY` must be provided in the environment e.g. through Helm secrets or the deployment will fail.