### PR TITLE
feat: add pre/post anonymise_user signals

### DIFF
--- a/template/docs/gdpr.md
+++ b/template/docs/gdpr.md
@@ -82,6 +82,45 @@ When anonymising:
 Provide an account deletion view that calls `anonymise_user` and logs the
 request. Do not silently hard-delete without the user's explicit confirmation.
 
+### Anonymisation signals
+
+`anonymise_user()` sends two signals, defined in `users/signals.py`. Apps that
+hold their own PII should hook these rather than adding calls to `gdpr.py`:
+
+| Signal | When | Use it for |
+| --- | --- | --- |
+| `pre_anonymise_user` | Before any field is overwritten | Cleanup that needs the original PII |
+| `post_anonymise_user` | After the user and allauth records are cleaned up | Work that does not need PII |
+
+Both receive the `User` class as `sender` and the instance as `user`.
+
+Use `pre_anonymise_user` when the receiver has to read the original values —
+unsubscribing an email address from a mailing list, deleting files named after
+the username, or clearing rows keyed on the old email. Once the pre-signal has
+returned, those values are gone for good.
+
+```python
+from django.dispatch import receiver
+
+from my_app.users.signals import post_anonymise_user, pre_anonymise_user
+
+
+@receiver(pre_anonymise_user)
+def unsubscribe_from_newsletter(sender, user, **kwargs):
+    # user.email is still the real address here
+    newsletter.unsubscribe(user.email)
+
+
+@receiver(post_anonymise_user)
+def clear_order_addresses(sender, user, **kwargs):
+    Order.objects.filter(user=user).update(shipping_address="")
+```
+
+Both signals are sent inside the anonymisation transaction, so a receiver's
+cleanup is committed atomically with the user record — and a receiver that
+raises rolls the entire anonymisation back. Connect receivers in the app's
+`AppConfig.ready()`.
+
 ---
 
 ## Data export — right of access

--- a/template/{{ package_name }}/users/gdpr.py.jinja
+++ b/template/{{ package_name }}/users/gdpr.py.jinja
@@ -14,6 +14,8 @@ from allauth.account.models import EmailAddress
 from allauth.socialaccount.models import SocialAccount
 from django.db import transaction
 
+from {{ package_name }}.users.signals import post_anonymise_user, pre_anonymise_user
+
 if TYPE_CHECKING:
     from {{ package_name }}.users.models import User
 
@@ -27,6 +29,8 @@ def anonymise_user(user: User) -> None:
 
     Add project-specific PII cleanup below the allauth block.
     """
+    pre_anonymise_user.send(sender=user.__class__, user=user)
+
     anon_id = f"deleted-{user.pk}"
 
     user.username = anon_id
@@ -48,3 +52,5 @@ def anonymise_user(user: User) -> None:
 
     EmailAddress.objects.filter(user=user).delete()
     SocialAccount.objects.filter(user=user).delete()
+
+    post_anonymise_user.send(sender=user.__class__, user=user)

--- a/template/{{ package_name }}/users/signals.py
+++ b/template/{{ package_name }}/users/signals.py
@@ -1,0 +1,12 @@
+"""Custom signals for the users app."""
+
+from django.dispatch import Signal
+
+# Sent before a user record is anonymised. Receivers get the User class as
+# `sender` and the not-yet-anonymised instance as `user`, so they can still
+# read the original PII (email, username) to clean up their own data.
+pre_anonymise_user = Signal()
+
+# Sent after a user record has been anonymised and allauth data removed.
+# Same arguments; the instance's PII fields are already overwritten.
+post_anonymise_user = Signal()


### PR DESCRIPTION
Lets apps that hold their own PII hook into GDPR erasure without editing `gdpr.py` directly.

## Changes

- **New** `template/{{ package_name }}/users/signals.py` — defines `pre_anonymise_user` and `post_anonymise_user`.
- `users/gdpr.py.jinja` — `anonymise_user()` sends `pre_anonymise_user` before any field is overwritten, and `post_anonymise_user` after the user and allauth records are cleaned up.
- `docs/gdpr.md` — new "Anonymisation signals" section under right-to-erasure, with a table of which signal to use when and a receiver example.

## Why a pre-signal

The pre-signal is the one that earns its place: a receiver that needs to unsubscribe an email address from a mailing list, delete files named after the username, or clear rows keyed on the old email has to run while those values still exist. Once anonymisation has overwritten them they are gone for good.

Both signals are sent inside the existing `@transaction.atomic` block, so a receiver's cleanup commits atomically with the user record and a raising receiver rolls the whole anonymisation back.

`sender` is the `User` class on both, matching Django's model-signal convention, with the instance passed as `user`.

## Verification

Regenerated from a clean `/tmp/my_app`:

- `pre-commit run --all-files` — clean (third pass; the first two are auto-formatters)
- `just typecheck` — 0 errors, 0 warnings
- `uv run pytest tests/` — 143 passed

Not run: the generated project's own Django suite (`just check-all`), which needs Docker services. Both `send()` calls are no-ops in the existing `test_gdpr.py` as no receivers are connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)